### PR TITLE
Fix ostree trigger of image compose job

### DIFF
--- a/jobs/ostree-compose.yml
+++ b/jobs/ostree-compose.yml
@@ -1,21 +1,21 @@
-- publisher:
-    name: ci-pipeline-ostree-image-publisher
-    publishers:
-        - conditional-publisher:
-            - condition-kind: shell
-              condition-command: |
-                  prev=$(curl $JENKINS_URL/job/{compose_job}/lastBuild/api/json 2>/dev/null | jq '.timestamp' | cut -c1-10)
-                  cur=$(date +%s)
-                  elapsed=$((cur - prev))
-                  if [ $elapsed -gt 86400 ]; then
-                     exit 0
-                  fi
-                  exit 1
-              on-evaluation-failure: dont-run
-              action:
-                  - trigger:
-                      project: '{compose_job}'
-                      threshold: 'SUCCESS'
+- builder:
+    name: ci-pipeline-ostree-image-trigger
+    builders:
+        - conditional-step:
+            condition-kind: shell
+            condition-command: |
+                prev=$(curl $JENKINS_URL/job/{compose_job}/lastBuild/api/json 2>/dev/null | jq '.timestamp' | cut -c1-10)
+                cur=$(date +%s)
+                elapsed=$((cur - prev))
+                if [ $elapsed -gt 86400 ]; then
+                   exit 0
+                fi
+                exit 1
+            on-evaluation-failure: dont-run
+            steps:
+                  - trigger-builds:
+                    - project: '{compose_job}'
+                      current-parameters: false
 
 - job:
     name: ci-pipeline-ostree-compose
@@ -29,11 +29,11 @@
                 export JENKINS_BUILD_TAG="${BUILD_TAG}"
                 export OSTREE_BRANCH="${OSTREE_BRANCH:-}"
             playbook: sig-atomic-buildscripts/centos-ci/setup/setup-system.yml
+        - ci-pipeline-ostree-image-trigger:
+            compose_job: ci-pipeline-ostree-image-trigger
 
     publishers:
         - ci-pipeline-duffy-publisher
-        - ci-pipeline-ostree-image-publisher:
-            compose_job: ci-pipeline-ostree-image-compose
 
 - job:
     name: ci-pipeline-ostree-image-compose


### PR DESCRIPTION
This PR changes the ostree publisher which triggers the image compose job to be a builder.  The reason this is necessary is that as is, the publisher is running twice for some reason.  It seems flexible publish has some conflict with other postbuild actions.  So, changing to a builder seems to fix this.  Functionally, it should make no difference, as it will be the last build step.  There is no threshold value in the builder, but that should be fine because if the previous build steps failed, I believe that no later build steps will execute - e.g. if the build step failed, this builder won't execute anyways.  This change seems to work.  Pretty sure the jjb is correct as well...