### PR TITLE
Fix to be an a list of projects not a string

### DIFF
--- a/jobs/rpmbuild.yml
+++ b/jobs/rpmbuild.yml
@@ -76,7 +76,7 @@
             artifacts: '*.*, */*, */*/*'
             allow-empty: 'true'
         - trigger-parameterized-builds:
-            project: 'ci-pipeline-ostree-compose'
-            predefined-parameters: fed_branch=$fed_branch
-            condition: SUCCESS
+            - project: 'ci-pipeline-ostree-compose'
+              predefined-parameters: fed_branch=$fed_branch
+              condition: SUCCESS
         - ci-pipeline-duffy-publisher


### PR DESCRIPTION
This should fix the failure.  This may have changed from 1.6.1 to 2.0.0

I recommend until we have a gate job or pipeline gate job we run through with 2.0.0 version we have in production which is this sha 7e1e54633f835d1c6ecd989452c9125c1ea9a921