### PR TITLE
Fix logic to echo rpm name to a file

### DIFF
--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -63,8 +63,6 @@ rm -rf libabigail
 git clone git://sourceware.org/git/libabigail.git
 RPM_TO_CHECK=$(find ${fed_repo}/results_${fed_repo}/${VERSION}/*/ -name "${fed_repo}-${VERSION}*" | grep -v src)
 libabigail/tools/fedabipkgdiff --from ${ABIGAIL_BRANCH} ${RPM_TO_CHECK} &> ${OUTPUTDIR}/logs/fedabipkgdiff_out.txt
-# Get just rpm name, not the entire path
-RPM_NAME=$(echo $RPM_TO_CHECK | sed 's/.*\///')
-echo "$RPM_NAME" >> ${OUTPUTDIR}/logs/packagename.txt
+basename $RPM_TO_CHECK >> ${OUTPUTDIR}/logs/packagename.txt
 
 exit 0

--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -63,6 +63,8 @@ rm -rf libabigail
 git clone git://sourceware.org/git/libabigail.git
 RPM_TO_CHECK=$(find ${fed_repo}/results_${fed_repo}/${VERSION}/*/ -name "${fed_repo}-${VERSION}*" | grep -v src)
 libabigail/tools/fedabipkgdiff --from ${ABIGAIL_BRANCH} ${RPM_TO_CHECK} &> ${OUTPUTDIR}/logs/fedabipkgdiff_out.txt
-echo "$RPM_TO_CHECK" >> ${OUTPUTDIR}/logs/packagename.txt
+# Get just rpm name, not the entire path
+RPM_NAME=$(echo $RPM_TO_CHECK | sed 's/.*\///')
+echo "$RPM_NAME" >> ${OUTPUTDIR}/logs/packagename.txt
 
 exit 0


### PR DESCRIPTION
Currently printing out the entire path to the rpm, I just want the full rpm file name without the path to it here.