### PR TITLE
fix up some python3 vs python2 compatibility issues, add verbosity

### DIFF
--- a/tasks/kernel-kt0
+++ b/tasks/kernel-kt0
@@ -49,7 +49,7 @@ EOF
 # Install net-tools
 sudo yum -y install net-tools
 # Start test VM
-ansible-playbook -i hosts ci-pipeline/config/libvirt-setup/setup-libvirt-image.yml -l kernel_install_slave_baremetal -e 'state=present'
+ansible-playbook -i hosts ci-pipeline/config/libvirt-setup/setup-libvirt-image.yml -l kernel_install_slave_baremetal -e 'state=present' -v
 
 PROVISION_STATUS=$?
 if [ "$PROVISION_STATUS" != 0 ]; then
@@ -62,7 +62,7 @@ IP=$(cat libvirt-hosts | tail -n 1 | cut -d '=' -f 2)
 
 cat << EOF > inventory
 [kernel_install_slave]
-$IP ansible_user=admin ansible_ssh_pass=admin ansible_become=true ansible_become_pass=admin
+$IP ansible_user=admin ansible_ssh_pass=admin ansible_become=true ansible_become_pass=admin ansible_python_interpreter=/usr/bin/python3
 EOF
 
 BRANCH=${fed_branch}
@@ -72,8 +72,8 @@ fi
 
 ansible-playbook -i inventory ci-pipeline/utils/kernel_install.yml --extra-vars "kernel=${kernel_vr}" --extra-vars "url=http://artifacts.ci.centos.org/artifacts/fedora-atomic/${BRANCH}/repo/kernel_repo/" -l kernel_install_slave -v > ${currentdir}/logs/kernel-install.out
 
-BOOT_STATUS=$?
-if [ "$BOOT_STATUS" != 0 ]; then
-    echo "ERROR: Provisioning\nSTATUS: $BOOT_STATUS"
+KERNEL_INSTALL_STATUS=$?
+if [ "$KERNEL_INSTALL_STATUS" != 0 ]; then
+    echo "ERROR: Upgrading Kernel\nSTATUS: $KERNEL_INSTALL_STATUS"
     exit 1
 fi


### PR DESCRIPTION
F25 has python3, not python, so had to fix that in the inventory file.
Also add -v to call to libvirt playbook as no tasks are failing, but the return code is 2 right now

Signed-off-by: Johnny Bieren <jbieren@redhat.com>