### PR TITLE
Prepare kernel job for fedmsg triggering

### DIFF
--- a/jobs/kernel_trigger.yml
+++ b/jobs/kernel_trigger.yml
@@ -38,9 +38,12 @@
 #        - shell: |
 #            set +e
 #            branch=$fed_branch
-#            if [ "$fed_repo" = "kernel" ] && [[ "$fed_ref" = *"f25"* ]]; then
+#            if [ "$fed_repo" = "kernel" ] && [[ "$fed_ref" = *"{os_major}"* ]]; then
 #                touch ${{WORKSPACE}}/trigger.downstream
 #            fi
+#            packagename=$(basename $fed_package_url)
+#            echo "packagename=$packagename" >> ${{WORKSPACE}}/job.properties
+#            echo "fed_branch={os_major}" >> ${{WORKSPACE}}/job.properties
     builders:
         - shell: |
             #!/bin/bash

--- a/jobs/kernel_trigger.yml
+++ b/jobs/kernel_trigger.yml
@@ -2,7 +2,45 @@
     name: ci-pipeline-kernel-trigger
     defaults: ci-pipeline-defaults
     triggers:
+#      - jms-messaging:
+#          selector: topic = 'org.centos.prod.ci.pipeline.package.complete'
+#          provider-name: fedora-fedmsg
       - timed: "*/5 * * * *"
+#    builders:
+#        - shell: |
+#            #!/bin/bash
+#            set -xuo pipefail
+#
+#            # Write script to parse fields (can likely be improved)
+#            cat << EOF > ${{WORKSPACE}}/parse_fedmsg.py
+#            #!/bin/env python
+#            import json
+#            import sys
+#
+#            reload(sys)
+#            sys.setdefaultencoding('utf-8')
+#            message = json.load(sys.stdin)
+#            if 'commit' in message:
+#                msg = message['commit']
+#
+#                for key in msg:
+#                    print "fed_%s=%s" % (key, msg[key])
+#            EOF
+#            chmod +x ${{WORKSPACE}}/parse_fedmsg.py
+#
+#            # Write fedmsg fields to a file to inject them
+#            if [ -n "$CI_MESSAGE" ]; then
+#                echo $CI_MESSAGE | ${{WORKSPACE}}/parse_fedmsg.py > fedmsg_fields.txt
+#            fi
+#
+#        - inject:
+#            properties-file: ${{WORKSPACE}}/fedmsg_fields.txt
+#        - shell: |
+#            set +e
+#            branch=$fed_branch
+#            if [ "$fed_repo" = "kernel" ] && [[ "$fed_ref" = *"f25"* ]]; then
+#                touch ${{WORKSPACE}}/trigger.downstream
+#            fi
     builders:
         - shell: |
             #!/bin/bash
@@ -20,7 +58,7 @@
             if [ -e "/tmp/kernel-{os_major}-trigger.txt" ]; then
                   OLD_TIMESTAMP=$(cat /tmp/kernel-{os_major}-trigger.txt)
                   if [ "$NEW_TIMESTAMP" != "$OLD_TIMESTAMP" ]; then
-                         touch $WORKSPACE/trigger.txt
+                         touch $WORKSPACE/trigger.downstream
                   fi
             fi
             echo $NEW_TIMESTAMP > /tmp/kernel-{os_major}-trigger.txt
@@ -31,7 +69,7 @@
     publishers:
       - conditional-publisher:
           - condition-kind: file-exists
-            condition-filename: trigger.txt
+            condition-filename: trigger.downstream
             action:
               - trigger-parameterized-builds:
                   - project: 'ci-pipeline-kernel-{os_major}-kt0'

--- a/tasks/kernel-kt0
+++ b/tasks/kernel-kt0
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+set -x
 # Find the base dir
 base_dir="$(dirname $0)/.."
 


### PR DESCRIPTION
Add commented out code to kernel trigger job so that once the rpmbuild job can publish fedmsg with the proper topic, the kernel trigger job can use that to trigger instead of hackish shell steps.  Also add set -x to kernel job for better output.