### PR TITLE
Align parameter names for kernel jobs

### DIFF
--- a/jobs/kernel_trigger.yml
+++ b/jobs/kernel_trigger.yml
@@ -66,7 +66,7 @@
             fi
             echo $NEW_TIMESTAMP > /tmp/kernel-{os_major}-trigger.txt
 
-            echo "packagename=$packagename" >> ${{WORKSPACE}}/job.properties
+            echo "kernel_nvr=$packagename" >> ${{WORKSPACE}}/job.properties
             echo "fed_branch={os_major}" >> ${{WORKSPACE}}/job.properties
 
     publishers:


### PR DESCRIPTION
The kt0 job has a kernel_nvr parameter, not packagename
Signed-off-by: Johnny Bieren <jbieren@redhat.com>