### PR TITLE
Turn on LTP testing for f25 kernel job

### DIFF
--- a/jobs/kernel-f25-kt0.yml
+++ b/jobs/kernel-f25-kt0.yml
@@ -30,3 +30,10 @@
             playbook: sig-atomic-buildscripts/centos-ci/setup/setup-system.yml
     publishers:
         - ci-pipeline-duffy-publisher
+        - email-ext:
+            recipients: jbieren@redhat.com, asavkov@redhat.com
+            reply-to: jbieren@redhat.com
+            subject: Build ${BUILD_NUMER} completed for public F25 Kernel Testing
+            body: The build link is here: ${BUILD_URL}. Currently set to email for all runs, regardless of pass or fail.
+            always: true
+            failure: false

--- a/jobs/rpmbuild.yml
+++ b/jobs/rpmbuild.yml
@@ -70,7 +70,25 @@
             echo "test_guidance=''" >> ${WORKSPACE}/job.properties_running
         - inject:
             properties-file: ${WORKSPACE}/job.properties_running
-# Will need a fedmsg here
+        - jms-messaging:
+            #override-topic: ${topic}
+            override-topic: org.centos.prod.ci.pipeline.package
+            provider-name: fedmsg
+            msg-type: Custom
+            msg-props: |
+              topic=${topic}
+              username=fedora-atomic
+            msg-content: |
+              {
+                "build_url": "${BUILD_URL}",
+                "build_id": "${BUILD_ID}",
+                "ref": "${ref}",
+                "rev": "${rev}",
+                "namespace": "${namespace}",
+                "repo": "${repo}",
+                "status": "${status}",
+                "test_guidance": "${test_guidance}"
+              }
         - ci-pipeline-duffy-builder:
             task: rpmbuild-test
             variables: |
@@ -93,7 +111,25 @@
             echo "package_url=http://artifacts.ci.centos.org/fedora-atomic/rawhide/repo/${fed_repo}_repo/$package" >> ${WORKSPACE}/job.properties
         - inject:
             properties-file: ${WORKSPACE}/job.properties
-# Will need a fedmsg here
+        - jms-messaging:
+            #override-topic: ${topic}
+            override-topic: org.centos.prod.ci.pipeline.package
+            provider-name: fedmsg
+            msg-type: Custom
+            msg-props: |
+              topic=${topic}
+              username=fedora-atomic
+            msg-content: |
+              {
+                "build_url": "${BUILD_URL}",
+                "build_id": "${BUILD_ID}",
+                "ref": "${ref}",
+                "rev": "${rev}",
+                "namespace": "${namespace}",
+                "repo": "${repo}",
+                "status": "${status}",
+                "test_guidance": "${test_guidance}"
+              }
     publishers:
         - archive:
             artifacts: '*.*, */*, */*/*'

--- a/jobs/rpmbuild_trigger.yml
+++ b/jobs/rpmbuild_trigger.yml
@@ -78,6 +78,25 @@
 
             echo "topic=org.centos.prod.ci.pipeline.package.queued" >> ${{WORKSPACE}}/job.properties
             touch ${{WORKSPACE}}/trigger.downstream
+        - jms-messaging:
+            #override-topic: ${{topic}}
+            override-topic: org.centos.prod.ci.pipeline.package
+            provider-name: fedmsg
+            msg-type: Custom
+            msg-props: |
+              topic=${{topic}}
+              username=fedora-atomic
+            msg-content: |
+              {{
+                "build_url": "${{BUILD_URL}}",
+                "build_id": "${{BUILD_ID}}",
+                "ref": "${{ref}}",
+                "rev": "${{rev}}",
+                "namespace": "${{namespace}}",
+                "repo": "${{repo}}",
+                "status": "${{status}}",
+                "test_guidance": "${{test_guidance}}"
+              }}
 
     publishers:
       - archive:

--- a/tasks/kernel-kt0
+++ b/tasks/kernel-kt0
@@ -79,3 +79,16 @@ if [ "$KERNEL_INSTALL_STATUS" != 0 ]; then
     echo "ERROR: Upgrading Kernel\nSTATUS: $KERNEL_INSTALL_STATUS"
     exit 1
 fi
+
+# Run asavkov script to run ltp suite
+git clone https://pagure.io/ktests
+pushd ktests/misc/ltp
+ansible-playbook -i inventory test_local.yml -l kernel_install_slave -v > ${currentdir}/logs/ltp-playbook.out
+LTP_STATUS=$?
+# Copy logs to proper location
+cp -rp artifacts/logs/ ${currentdir}/logs/ltp
+if [ "$LTP_STATUS" != 0 ]; then
+    echo "ERROR: LTP Testing\nSTATUS: $LTP_STATUS"
+    exit 1
+fi
+popd


### PR DESCRIPTION
This enables a playbook to run the LTP testing suite if the kernel installed successfully.  It copies the logs to the proper directory so that they should be archived properly.  Once this is running and confirmed to be working as expected, I will add another PR to put fedmsgs around this.