### PR TITLE
Remove test guidance from rpmbuild messages

### DIFF
--- a/jobs/rpmbuild.yml
+++ b/jobs/rpmbuild.yml
@@ -87,7 +87,7 @@
                 "namespace": "${namespace}",
                 "repo": "${repo}",
                 "status": "${status}",
-                "test_guidance": "${test_guidance}"
+                "test_guidance": ""
               }
         - ci-pipeline-duffy-builder:
             task: rpmbuild-test
@@ -129,7 +129,7 @@
                 "namespace": "${namespace}",
                 "repo": "${repo}",
                 "status": "${status}",
-                "test_guidance": "${test_guidance}"
+                "test_guidance": ""
               }
     publishers:
         - archive:

--- a/jobs/rpmbuild.yml
+++ b/jobs/rpmbuild.yml
@@ -59,15 +59,17 @@
 #            command: build.description = build.getEnvironment().get('fed_repo')
         - shell: |
             # Write ci message fields to a file
-            echo "topic=org.centos.prod.ci.pipeline.package.running" >> ${WORKSPACE}/job.properties_running
-            echo "build_url=$BUILD_URL" >> ${WORKSPACE}/job.properties_running
-            echo "build_id=$BUILD_ID" >> ${WORKSPACE}/job.properties_running
-            echo "ref=fedora/${fed_branch}/x86_64/atomic-host" >> ${WORKSPACE}/job.properties_running
-            echo "rev=$fed_rev" >> ${WORKSPACE}/job.properties_running
-            echo "namespace=rpms" >> ${WORKSPACE}/job.properties_running
-            echo "repo=$fed_repo" >> ${WORKSPACE}/job.properties_running
-            echo "status=success" >> ${WORKSPACE}/job.properties_running
-            echo "test_guidance=''" >> ${WORKSPACE}/job.properties_running
+            cat << EOF >> ${WORKSPACE}/job.properties_running
+               topic=org.centos.prod.ci.pipeline.package.running
+               build_url=$BUILD_URL
+               build_id=$BUILD_ID
+               ref=fedora/${fed_branch}/x86_64/atomic-host
+               rev=$fed_rev
+               namespace=rpms
+               repo=$fed_repo
+               status=success
+               test_guidance=
+            EOF
         - inject:
             properties-file: ${WORKSPACE}/job.properties_running
         - jms-messaging:
@@ -87,7 +89,7 @@
                 "namespace": "${namespace}",
                 "repo": "${repo}",
                 "status": "${status}",
-                "test_guidance": ""
+                "test_guidance": "${test_guidance}"
               }
         - ci-pipeline-duffy-builder:
             task: rpmbuild-test
@@ -129,7 +131,7 @@
                 "namespace": "${namespace}",
                 "repo": "${repo}",
                 "status": "${status}",
-                "test_guidance": ""
+                "test_guidance": "${test_guidance}"
               }
     publishers:
         - archive:

--- a/jobs/rpmbuild_trigger.yml
+++ b/jobs/rpmbuild_trigger.yml
@@ -48,12 +48,14 @@
                 branch="rawhide"
             fi
             # Set some message properties that are true for all messages
-            echo "ref=fedora/${{branch}}/x86_64/atomic-host" >> ${{WORKSPACE}}/job.properties
-            echo "rev=$fed_rev" >> ${{WORKSPACE}}/job.properties
-            echo "namespace=rpms" >> ${{WORKSPACE}}/job.properties
-            echo "repo=$fed_repo" >> ${{WORKSPACE}}/job.properties
-            echo "status=success" >> ${{WORKSPACE}}/job.properties
-            echo "test_guidance=''" >> ${{WORKSPACE}}/job.properties
+            cat << EOF >> ${{WORKSPACE}}/job.properties
+               ref=fedora/${{branch}}/x86_64/atomic-host
+               rev=$fed_rev
+               namespace=rpms
+               repo=$fed_repo
+               status=success
+               test_guidance=
+            EOF
             # Verify this is a development branch
             if [[ ! "$fed_branch" =~ {targets} ]]; then
                 echo "$fed_branch is not in the list"
@@ -95,7 +97,7 @@
                 "namespace": "${{namespace}}",
                 "repo": "${{repo}}",
                 "status": "${{status}}",
-                "test_guidance": ""
+                "test_guidance": "${{test_guidance}}"
               }}
 
     publishers:

--- a/jobs/rpmbuild_trigger.yml
+++ b/jobs/rpmbuild_trigger.yml
@@ -95,7 +95,7 @@
                 "namespace": "${{namespace}}",
                 "repo": "${{repo}}",
                 "status": "${{status}}",
-                "test_guidance": "${{test_guidance}}"
+                "test_guidance": ""
               }}
 
     publishers:


### PR DESCRIPTION
I am getting null pointer exceptions in the CI notifier when I have   "test_guidance": "${test_guidance}" when test_guidance='' so just remove it and use "" as the value instead.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>