### PR TITLE
make some jms stuff publisher in case build step fails

### DIFF
--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -43,6 +43,7 @@ fi
 # Build the package into ./results_${fed_repo}/$VERSION/$RELEASE/
 fedpkg --release ${fed_branch} mockbuild
 MOCKBUILD_STATUS=$?
+sudo echo "status=$MOCKBUILD_STATUS" >> ${OUTPUTDIR}/logs/package_props.txt
 if [ "$MOCKBUILD_STATUS" != 0 ]; then echo "ERROR: FEDPKG MOCKBUILD\nSTATUS: $MOCKBUILD_STATUS"; exit 1; fi
 popd
 
@@ -63,6 +64,7 @@ rm -rf libabigail
 git clone git://sourceware.org/git/libabigail.git
 RPM_TO_CHECK=$(find ${fed_repo}/results_${fed_repo}/${VERSION}/*/ -name "${fed_repo}-${VERSION}*" | grep -v src)
 libabigail/tools/fedabipkgdiff --from ${ABIGAIL_BRANCH} ${RPM_TO_CHECK} &> ${OUTPUTDIR}/logs/fedabipkgdiff_out.txt
-basename $RPM_TO_CHECK >> ${OUTPUTDIR}/logs/packagename.txt
+RPM_NAME=$(basename $RPM_TO_CHECK)
+echo "package_url=http://artifacts.ci.centos.org/fedora-atomic/${fed_branch}/repo/${fed_repo}_repo/$RPM_NAME" >> ${OUTPUTDIR}/logs/package_props.txt
 
 exit 0

--- a/jobs/rpmbuild.yml
+++ b/jobs/rpmbuild.yml
@@ -105,21 +105,18 @@
             properties-file: ${WORKSPACE}/logs/description.txt
 #        - system-groovy:
 #            command: build.description = build.getEnvironment().get('description')
-        - shell: |
-            echo "topic=org.centos.prod.ci.pipeline.package.complete" >> ${WORKSPACE}/job.properties
-            package=$(cat ${WORKSPACE}/logs/packagename.txt)
-            status=$(curl $JENKINS_URL/job/$JOB_NAME/lastBuild/api/json 2>/dev/null | jq '.result')
-            echo "status=$status" >> ${WORKSPACE}/job.properties
-            echo "package_url=http://artifacts.ci.centos.org/fedora-atomic/rawhide/repo/${fed_repo}_repo/$package" >> ${WORKSPACE}/job.properties
         - inject:
-            properties-file: ${WORKSPACE}/job.properties
+            properties-file: ${WORKSPACE}/logs/package_props.txt
+    publishers:
+        - archive:
+            artifacts: '*.*, */*, */*/*'
+            allow-empty: 'true'
         - jms-messaging:
-            #override-topic: ${topic}
-            override-topic: org.centos.prod.ci.pipeline.package
+            override-topic: org.centos.prod.ci.pipeline.package.complete
             provider-name: fedmsg
             msg-type: Custom
             msg-props: |
-              topic=${topic}
+              topic=org.centos.prod.ci.pipeline.package.complete
               username=fedora-atomic
             msg-content: |
               {
@@ -133,10 +130,6 @@
                 "status": "${status}",
                 "test_guidance": "${test_guidance}"
               }
-    publishers:
-        - archive:
-            artifacts: '*.*, */*, */*/*'
-            allow-empty: 'true'
         - trigger-parameterized-builds:
             - project: 'ci-pipeline-ostree-compose'
               predefined-parameters: fed_branch=$fed_branch

--- a/jobs/rpmbuild.yml
+++ b/jobs/rpmbuild.yml
@@ -105,12 +105,14 @@
             properties-file: ${WORKSPACE}/logs/description.txt
 #        - system-groovy:
 #            command: build.description = build.getEnvironment().get('description')
-        - inject:
-            properties-file: ${WORKSPACE}/logs/package_props.txt
     publishers:
         - archive:
             artifacts: '*.*, */*, */*/*'
             allow-empty: 'true'
+        - postbuildscript:
+            builders:
+                - inject:
+                    properties-file: ${WORKSPACE}/logs/package_props.txt
         - jms-messaging:
             override-topic: org.centos.prod.ci.pipeline.package.complete
             provider-name: fedmsg

--- a/jobs/rpmbuild_trigger.yml
+++ b/jobs/rpmbuild_trigger.yml
@@ -80,31 +80,30 @@
 
             echo "topic=org.centos.prod.ci.pipeline.package.queued" >> ${{WORKSPACE}}/job.properties
             touch ${{WORKSPACE}}/trigger.downstream
-        - jms-messaging:
-            #override-topic: ${{topic}}
-            override-topic: org.centos.prod.ci.pipeline.package
-            provider-name: fedmsg
-            msg-type: Custom
-            msg-props: |
-              topic=${{topic}}
-              username=fedora-atomic
-            msg-content: |
-              {{
-                "build_url": "${{BUILD_URL}}",
-                "build_id": "${{BUILD_ID}}",
-                "ref": "${{ref}}",
-                "rev": "${{rev}}",
-                "namespace": "${{namespace}}",
-                "repo": "${{repo}}",
-                "status": "${{status}}",
-                "test_guidance": "${{test_guidance}}"
-              }}
 
     publishers:
       - archive:
           artifacts: '*.*'
           allow-empty: 'true'
-      # Will need fedmsg publisher here once available
+      - jms-messaging:
+          #override-topic: ${{topic}}
+          override-topic: org.centos.prod.ci.pipeline.package
+          provider-name: fedmsg
+          msg-type: Custom
+          msg-props: |
+            topic=${{topic}}
+            username=fedora-atomic
+          msg-content: |
+            {{
+              "build_url": "${{BUILD_URL}}",
+              "build_id": "${{BUILD_ID}}",
+              "ref": "${{ref}}",
+              "rev": "${{rev}}",
+              "namespace": "${{namespace}}",
+              "repo": "${{repo}}",
+              "status": "${{status}}",
+              "test_guidance": "${{test_guidance}}"
+            }}
       - conditional-publisher:
           - condition-kind: file-exists
             condition-filename: trigger.downstream

--- a/jobs/rpmbuild_trigger.yml
+++ b/jobs/rpmbuild_trigger.yml
@@ -85,6 +85,10 @@
       - archive:
           artifacts: '*.*'
           allow-empty: 'true'
+      - postbuildscript:
+          builders:
+              - inject:
+                 properties-file: ${{WORKSPACE}}/job.properties
       - jms-messaging:
           #override-topic: ${{topic}}
           override-topic: org.centos.prod.ci.pipeline.package


### PR DESCRIPTION
Bill made a good point that if the build step fails, subsequent build steps will not happen so we will not publish.  So, change the jms stuff to publisher where it makes sense.  This is very much dependent on inject still running if the build step fails before it.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>