### PR TITLE
Clean up rpmbuild fedmsgs

### DIFF
--- a/jobs/rpmbuild.yml
+++ b/jobs/rpmbuild.yml
@@ -59,19 +59,19 @@
 #            command: build.description = build.getEnvironment().get('fed_repo')
         - shell: |
             # Write ci message fields to a file
-            cat << EOF >> ${WORKSPACE}/job.properties_running
-               topic=org.centos.prod.ci.pipeline.package.running
-               build_url=$BUILD_URL
-               build_id=$BUILD_ID
-               ref=fedora/${fed_branch}/x86_64/atomic-host
-               rev=$fed_rev
-               namespace=rpms
-               repo=$fed_repo
-               status=success
-               test_guidance=
+            cat << EOF >> ${WORKSPACE}/job.properties
+            topic=org.centos.prod.ci.pipeline.package.running
+            build_url=$BUILD_URL
+            build_id=$BUILD_ID
+            ref=fedora/${fed_branch}/x86_64/atomic-host
+            rev=$fed_rev
+            namespace=rpms
+            repo=$fed_repo
+            status=success
+            test_guidance=
             EOF
         - inject:
-            properties-file: ${WORKSPACE}/job.properties_running
+            properties-file: ${WORKSPACE}/job.properties
         - jms-messaging:
             #override-topic: ${topic}
             override-topic: org.centos.prod.ci.pipeline.package

--- a/jobs/rpmbuild_trigger.yml
+++ b/jobs/rpmbuild_trigger.yml
@@ -47,15 +47,7 @@
             if [ "$branch" = "master" ]; then
                 branch="rawhide"
             fi
-            # Set some message properties that are true for all messages
-            cat << EOF >> ${{WORKSPACE}}/job.properties
-               ref=fedora/${{branch}}/x86_64/atomic-host
-               rev=$fed_rev
-               namespace=rpms
-               repo=$fed_repo
-               status=success
-               test_guidance=
-            EOF
+            echo "branch=$branch" >> ${{WORKSPACE}}/job.properties
             # Verify this is a development branch
             if [[ ! "$fed_branch" =~ {targets} ]]; then
                 echo "$fed_branch is not in the list"
@@ -101,12 +93,12 @@
             {{
               "build_url": "${{BUILD_URL}}",
               "build_id": "${{BUILD_ID}}",
-              "ref": "${{ref}}",
-              "rev": "${{rev}}",
-              "namespace": "${{namespace}}",
-              "repo": "${{repo}}",
-              "status": "${{status}}",
-              "test_guidance": "${{test_guidance}}"
+              "ref": "fedora/${{branch}}/x86_64/atomic-host",
+              "rev": "${{fed_rev}}",
+              "namespace": "rpms",
+              "repo": "${{fed_repo}}",
+              "status": "success",
+              "test_guidance": ""
             }}
       - conditional-publisher:
           - condition-kind: file-exists


### PR DESCRIPTION
In jobs/rpmbuild.yml, the fedmsg fields are used in both a builder and publisher, so we write them to a file.   job.properties was replaced by package_props.txt, so I got rid of _running since it is the only job.properties now.  Also fix the cat << EOF >> so the fields aren't all messed up and give null pointer exceptions.

In jobs/rpmbuild_trigger.yml, we only have one instance of jms_messaging so it makes no sense to cat the fields to a file, just put them right in the publisher.