### PR TITLE
Turn off kubernetes rpm install for now

### DIFF
--- a/utils/ostree_install_rpms.yml
+++ b/utils/ostree_install_rpms.yml
@@ -10,7 +10,7 @@
     shell: "rpm-ostree install {{ item }}"
     with_items:
       - etcd
-      - kubernetes
+#      - kubernetes
   - name: Reboot the atomic host
     shell: "sleep 3 && systemctl reboot"
     async: 1


### PR DESCRIPTION
The kubernetes testing fails right now anyways, and I am getting errors installing the kubernetes rpm, so just turn this off for now so that we can get at least some of the testing going.
Signed-off-by: Johnny Bieren <jbieren@redhat.com>