### PR TITLE
Don't only inject if build passes

### DIFF
--- a/jobs/rpmbuild.yml
+++ b/jobs/rpmbuild.yml
@@ -110,6 +110,7 @@
             artifacts: '*.*, */*, */*/*'
             allow-empty: 'true'
         - postbuildscript:
+            script-only-if-succeeded: false
             builders:
                 - inject:
                     properties-file: ${WORKSPACE}/logs/package_props.txt

--- a/jobs/rpmbuild_trigger.yml
+++ b/jobs/rpmbuild_trigger.yml
@@ -78,6 +78,7 @@
           artifacts: '*.*'
           allow-empty: 'true'
       - postbuildscript:
+          script-only-if-succeeded: false
           builders:
               - inject:
                  properties-file: ${{WORKSPACE}}/job.properties

--- a/tasks/atomic-host-tests
+++ b/tasks/atomic-host-tests
@@ -133,10 +133,11 @@ ansible-playbook -i ${HOMEDIR}/ansible_inventory.txt -l testsystems ../${base_di
 
 # Legitimate failure with this right now, need to figure out
 # - Timeout when waiting for apiserver on 127.0.0.1
-ansible-playbook -i ${HOMEDIR}/ansible_inventory.txt -l testsystems tests/k8-cluster/main.yml -u root -v > ${HOMEDIR}/logs/k8-cluster.out
-K8_CLUSTER_RC=$?
-OUTPUTARRAY[k8-cluster]=$K8_CLUSTER_RC
-ansible-playbook -i ${HOMEDIR}/ansible_inventory.txt -l testsystems ../${base_dir}/utils/atomic_rollback.yml -u root
+# This test also asks for a password mid test, disable until I figure that out
+#ansible-playbook -i ${HOMEDIR}/ansible_inventory.txt -l testsystems tests/k8-cluster/main.yml -u root -v > ${HOMEDIR}/logs/k8-cluster.out
+#K8_CLUSTER_RC=$?
+#OUTPUTARRAY[k8-cluster]=$K8_CLUSTER_RC
+#ansible-playbook -i ${HOMEDIR}/ansible_inventory.txt -l testsystems ../${base_dir}/utils/atomic_rollback.yml -u root
 
 # Test requires two images so it can upgrade/rollback
 # Have only seen this test pass on rawhide ostrees so far


### PR DESCRIPTION
Also turn off k8-cluster testing for now as that password prompts too

Signed-off-by: Johnny Bieren <jbieren@redhat.com>