### PR TITLE
Split boot sanity into two jenkins jobs.

### DIFF
--- a/jobs/ostree-compose.yml
+++ b/jobs/ostree-compose.yml
@@ -2,45 +2,43 @@
     name: ci-pipeline-ostree-boot-trigger
     publishers:
         - trigger-parameterized-builds:
-            - project: ci-pipeline-ostree-boot-sanity
+            - project: '{boot_job}'
               current-parameters: true
-              property-file: ${WORKSPACE}/logs/ostree.props
+              property-file: ${{WORKSPACE}}/logs/ostree.props
               block: false
               same-node: true
               condition: SUCCESS
 
-- publisher:
+- builder:
     name: ci-pipeline-ostree-image-trigger
-    publishers:
-        - postbuildscript:
-            builders:
-                - conditional-step:
-                    condition-kind: shell
-                    condition-command: |
-                        prev=0
-                        number=$(curl $JENKINS_URL/job/{compose_job}/lastBuild/api/json 2>/dev/null | jq '.number')
-                        for ((i=$number; i>0; i--)); do
-                            branch=$(curl $JENKINS_URL/job/{compose_job}/$i/api/json 2>/dev/null | jq -r '.actions[] | select(.parameters).parameters[] | select(.name | contains("fed_branch")).value')
-                            if [ "$branch" = "$fed_branch" ]; then
-                                result=$(curl $JENKINS_URL/job/{compose_job}/$i/api/json 2>/dev/null| jq -r '.result')
-                                if [ "$result" = "SUCCESS" ]; then
-                                    prev=$(curl $JENKINS_URL/job/{compose_job}/$i/api/json 2>/dev/null| jq '.timestamp' | cut -c1-10)
-                                    break
-                                fi
-                            fi
-                        done
-                        cur=$(date +%s)
-                        elapsed=$((cur - prev))
-                        if [ $elapsed -gt 86400 ]; then
-                           exit 0
+    builders:
+        - conditional-step:
+            condition-kind: shell
+            condition-command: |
+                prev=0
+                number=$(curl $JENKINS_URL/job/{compose_job}/lastBuild/api/json 2>/dev/null | jq '.number')
+                for ((i=$number; i>0; i--)); do
+                    branch=$(curl $JENKINS_URL/job/{compose_job}/$i/api/json 2>/dev/null | jq -r '.actions[] | select(.parameters).parameters[] | select(.name | contains("fed_branch")).value')
+                    if [ "$branch" = "$fed_branch" ]; then
+                        result=$(curl $JENKINS_URL/job/{compose_job}/$i/api/json 2>/dev/null| jq -r '.result')
+                        if [ "$result" = "SUCCESS" ]; then
+                            prev=$(curl $JENKINS_URL/job/{compose_job}/$i/api/json 2>/dev/null| jq '.timestamp' | cut -c1-10)
+                            break
                         fi
-                        exit 1
-                    on-evaluation-failure: dont-run
-                    steps:
-                          - trigger-builds:
-                            - project: '{compose_job}'
-                              current-parameters: true
-            script-only-if-succeeded: false
+                    fi
+                done
+                cur=$(date +%s)
+                elapsed=$((cur - prev))
+                if [ $elapsed -gt 86400 ]; then
+                   exit 0
+                fi
+                exit 1
+            on-evaluation-failure: dont-run
+            steps:
+                  - trigger-builds:
+                    - project: '{compose_job}'
+                      current-parameters: true
+                      property-file: ${{WORKSPACE}}/logs/ostree.props
 
 - job:
     name: ci-pipeline-ostree-compose
@@ -98,6 +96,8 @@
         - inject:
             properties-file: ${WORKSPACE}/logs/ostree.props
             override-build-parameters: true
+        - ci-pipeline-ostree-image-trigger:
+            compose_job: ci-pipeline-ostree-image-compose
     publishers:
         - ci-pipeline-duffy-publisher
         - jms-messaging:
@@ -120,9 +120,8 @@
                     "status": "${BUILD_STATUS}",
                     "test_guidance": ""
                 }
-        - ci-pipeline-ostree-boot-trigger
-        - ci-pipeline-ostree-image-trigger:
-            compose_job: ci-pipeline-ostree-image-compose
+        - ci-pipeline-ostree-boot-trigger:
+            boot_job: ci-pipeline-ostree-boot-sanity
 
 - job:
     name: ci-pipeline-ostree-image-compose
@@ -135,7 +134,7 @@
         - string:
             name: commit
             description: |
-              sha pointing to the particular commit we want to test
+              sha pointing to the particular commit we want to build
     builders:
         - shell: |
             > ${WORKSPACE}/job.properties
@@ -204,10 +203,54 @@
                     "test_guidance": "",
                     "type": "qcow2"
                 }
-        - ci-pipeline-ostree-boot-trigger
+        - ci-pipeline-ostree-boot-trigger:
+            boot_job: ci-pipeline-ostree-image-boot-sanity
 
 - job:
     name: ci-pipeline-ostree-boot-sanity
+    defaults: ci-pipeline-defaults
+    parameters:
+        - string:
+            name: fed_branch
+            description: |
+              which branch to test
+        - string:
+            name: image2boot
+            description: |
+              url pointing to the image to boot
+        - string:
+            name: image_name
+            description: |
+              name of the image
+        - string:
+            name: commit
+            description: |
+              sha pointing to the particular commit we want to test
+    builders:
+        - shell: |
+            > ${WORKSPACE}/job.properties
+            if [ "$fed_branch" = "master" ]; then
+                echo "fed_branch=rawhide" > ${WORKSPACE}/job.properties
+            fi
+        - inject:
+            properties-file: ${WORKSPACE}/job.properties
+            override-build-parameters: true
+        - ci-pipeline-duffy-builder:
+            task: ostree-boot-image
+            variables: |
+                export BUILD="${fed_branch}"
+                export image2boot="${image2boot:-}"
+                export commit=${commit:-}
+                export JENKINS_JOB_NAME="${JOB_NAME}"
+                export JENKINS_BUILD_TAG="${BUILD_TAG}"
+                export OSTREE_BRANCH="${OSTREE_BRANCH:-}"
+                export ANSIBLE_HOST_KEY_CHECKING="False"
+            playbook: sig-atomic-buildscripts/centos-ci/setup/setup-system.yml
+    publishers:
+        - ci-pipeline-duffy-publisher
+
+- job:
+    name: ci-pipeline-ostree-image-boot-sanity
     defaults: ci-pipeline-defaults
     parameters:
         - string:

--- a/tasks/ostree-image-compose
+++ b/tasks/ostree-image-compose
@@ -112,12 +112,13 @@ find ./images -mtime +3 -exec rm {} \;
 # Also delete if we have more than 3 images (from manual runs)
 pushd images
 ls -t | sed -e '1,3d' | xargs --no-run-if-empty -d '\n' rm
+ln -sf $imgname.qcow2 latest-atomic.qcow2
 popd
 
 # Record the commit so we can test it later
 commit=$(ostree --repo=ostree rev-parse ${REF})
 cat << EOF > logs/ostree.props
-commit=$commit
+builtcommit=$commit
 image2boot="http://artifacts.ci.centos.org/artifacts/fedora-atomic/${BUILD}/images/$imgname.qcow2"
 image_name="$imgname.qcow2"
 EOF


### PR DESCRIPTION
One for ostree/repo and one for ostree/image.

move image creation back to a builder step.  We really don't want to trigger if the ostree repo creation failed.

commit from ostree repo creation should get passed all the way to boot sanity testing.

Create a latest-atomic.qcow2 symlink.