### PR TITLE
Add fedmsgs to atomic-host-tests

### DIFF
--- a/jobs/atomic-host-tests.yml
+++ b/jobs/atomic-host-tests.yml
@@ -11,6 +11,25 @@
             description: |
               url pointing to the image to boot
     builders:
+        - jms-messaging:
+            override-topic: org.centos.prod.ci.pipeline.compose.test.integration.running
+            provider-name: fedora-fedmsg
+            msg-type: Custom
+            msg-props: |
+                topic=org.centos.prod.ci.pipeline.compose.test.integration.running
+                username=fedora-atomic
+            msg-content: |
+                {
+                    "build_url": "${BUILD_URL}",
+                    "compose_url": "http://artifacts.ci.centos.org/artifacts/fedora-atomic/${fed_branch}/ostree",
+                    "build_id": "${BUILD_ID}",
+                    "ref": "fedora/${fed_branch}/x86_64/atomic-host",
+                    "rev": "${rev}",
+                    "namespace": "rpms",
+                    "repo": "${fed_repo}",
+                    "status": "success",
+                    "test_guidance": ""
+                }
         - ci-pipeline-duffy-builder:
             task: atomic-host-tests
             variables: |
@@ -36,3 +55,22 @@
                     pattern: "$WORKSPACE/logs/ansible_xunit.xml"
                     stoponerror: true
                     deleteoutput: false
+        - jms-messaging:
+            override-topic: org.centos.prod.ci.pipeline.compose.test.integration.complete
+            provider-name: fedora-fedmsg
+            msg-type: Custom
+            msg-props: |
+                topic=org.centos.prod.ci.pipeline.compose.test.integration.complete
+                username=fedora-atomic
+            msg-content: |
+                {
+                    "build_url": "${BUILD_URL}",
+                    "compose_url": "http://artifacts.ci.centos.org/artifacts/fedora-atomic/${fed_branch}/ostree",
+                    "build_id": "${BUILD_ID}",
+                    "ref": "fedora/${fed_branch}/x86_64/atomic-host",
+                    "rev": "${rev}",
+                    "namespace": "rpms",
+                    "repo": "${fed_repo}",
+                    "status": "TODO",
+                    "test_guidance": ""
+                }

--- a/jobs/ostree-compose.yml
+++ b/jobs/ostree-compose.yml
@@ -248,6 +248,34 @@
             playbook: sig-atomic-buildscripts/centos-ci/setup/setup-system.yml
     publishers:
         - ci-pipeline-duffy-publisher
+        - trigger-parameterized-builds:
+          - project: 'ci-pipeline-atomic-host-tests'
+            current-parameters: true
+            condition: SUCCESS
+        - conditional-publisher:
+            - condition-kind: current-status
+              condition-worst: SUCCESS
+              condition-best: SUCCESS
+              action:
+                  - jms-messaging:
+                      override-topic: org.centos.prod.ci.pipeline.compose.test.integration.queued
+                      provider-name: fedora-fedmsg
+                      msg-type: Custom
+                      msg-props: |
+                          topic=org.centos.prod.ci.pipeline.compose.test.integration.queued
+                          username=fedora-atomic
+                      msg-content: |
+                          {
+                              "build_url": "${BUILD_URL}",
+                              "compose_url": "http://artifacts.ci.centos.org/artifacts/fedora-atomic/${fed_branch}/ostree",
+                              "build_id": "${BUILD_ID}",
+                              "ref": "fedora/${fed_branch}/x86_64/atomic-host",
+                              "rev": "${rev}",
+                              "namespace": "rpms",
+                              "repo": "${fed_repo}",
+                              "status": "success",
+                              "test_guidance": ""
+                          }
 
 - job:
     name: ci-pipeline-ostree-image-boot-sanity
@@ -337,7 +365,3 @@
                     "test_guidance": "",
                     "type": "qcow2"
                 }
-        - trigger-parameterized-builds:
-          - project: 'ci-pipeline-atomic-host-tests'
-            current-parameters: true
-            condition: SUCCESS


### PR DESCRIPTION
Leaving the .complete message in atomic-host-tests as TODO for now so I can devise a smart solution for that tomorrow

Signed-off-by: Johnny Bieren <jbieren@redhat.com>