### PR TITLE
Fix atomic hosts xunit path

### DIFF
--- a/jobs/atomic-host-tests.yml
+++ b/jobs/atomic-host-tests.yml
@@ -52,7 +52,7 @@
                     failurenew: 0
             types:
                 - junit:
-                    pattern: "$WORKSPACE/logs/ansible_xunit.xml"
+                    pattern: "logs/ansible_xunit.xml"
                     stoponerror: true
                     deleteoutput: false
         - jms-messaging:


### PR DESCRIPTION
$WORKSPACE is not supported in the xunit publisher path.  Thanks Bill