### PR TITLE
Attempt at fixing ltp run

### DIFF
--- a/tasks/kernel-kt0
+++ b/tasks/kernel-kt0
@@ -88,7 +88,9 @@ pushd ktests/misc/ltp
 ansible-playbook -i ../../../inventory test_local.yml -l kernel_install_slave -v > ${currentdir}/logs/ltp-playbook.out
 LTP_STATUS=$?
 # Copy logs to proper location
-cp -rp artifacts/logs/ ${currentdir}/logs/ltp
+sshpass -p admin scp -rp admin@$IP:/mnt/testarea/ltp/logs ${currentdir}/logs/ltp
+# Grep dmesg as that won't happen in in the playbook currently
+./dmesg_grep.sh ${currentdir}/logs/ltp/ltp-dmesg* ./artifacts/ctlogs
 if [ "$LTP_STATUS" != 0 ]; then
     echo "ERROR: LTP Testing\nSTATUS: $LTP_STATUS"
     exit 1


### PR DESCRIPTION
Currently, something in the ltp testing suite kills the ssh connection, so despite the task for synchronizing the logs being in an always: block, it does not run as the ssh connection is killed.  However, it appears the logs are there once the playbook finishes regardless, so manually scp them as a hackish solution for now.  Also adding in that dmesg command, as it is another task in the playbook that isn't running.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>