### PR TITLE
Allow rpmbuild jobs to be concurrent

### DIFF
--- a/jobs/rpmbuild.yml
+++ b/jobs/rpmbuild.yml
@@ -1,6 +1,7 @@
 - job:
     name: ci-pipeline-rpmbuild
     defaults: ci-pipeline-defaults
+    concurrent: true
     parameters:
         - string:
             name: fed_username

--- a/jobs/rpmbuild_trigger.yml
+++ b/jobs/rpmbuild_trigger.yml
@@ -1,6 +1,7 @@
 - job-template:
     name: ci-pipeline-rpmbuild-trigger
     defaults: ci-pipeline-defaults
+    concurrent: true
     triggers:
       - jms-messaging:
           selector: topic = 'org.fedoraproject.prod.git.receive'


### PR DESCRIPTION
We have 24 executors now in the CentOS ci environment, so I would like to see if concurrency works.  This would be a big help for rpmbuild, as kernel builds tend to take multiple hours and generate quite a queue.  Unsure if this will *just work* or will need further changes, so this is one way to find out.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>