### PR TITLE
Clean up noise in log files.

### DIFF
--- a/config/libvirt-setup/roles/libvirt-system/tasks/main.yml
+++ b/config/libvirt-setup/roles/libvirt-system/tasks/main.yml
@@ -4,7 +4,7 @@
   when: state == 'present'
 - include: vm-import.yml
   with_dict: '{{ libvirt_systems }}'
-  when: "state == 'present' and '{{ item.key }}' not in virt_vms.list_vms"
+  when: "state == 'present' and item.key not in virt_vms.list_vms"
 - include: vm-destroy.yml
   with_dict: '{{ libvirt_systems }}'
-  when: "state == 'absent' and '{{ item.key }}' in virt_vms.list_vms"
+  when: "state == 'absent' and item.key in virt_vms.list_vms"


### PR DESCRIPTION
these are ansible variables and don't need to be referenced via jinja2.