### PR TITLE
Change duffy timeout to a variable and set it higher in kernel job

### DIFF
--- a/jobs/atomic-host-tests.yml
+++ b/jobs/atomic-host-tests.yml
@@ -36,6 +36,7 @@
                 export ANSIBLE_HOST_KEY_CHECKING="False"
                 export BUILD="${fed_branch}"
                 export image2boot="${image2boot:-}"
+            timeout: 3600
             playbook: sig-atomic-buildscripts/centos-ci/setup/setup-system.yml
     publishers:
         - ci-pipeline-duffy-publisher

--- a/jobs/ci-pipeline-defaults.yml
+++ b/jobs/ci-pipeline-defaults.yml
@@ -71,7 +71,7 @@
     builders:
         - macro-cciskel-duffy-prepared-allocate:
             jobclass: builder
-            duffytimeoutsecs: 3600
+            duffytimeoutsecs: '{timeout}'
             playbook: '{playbook}'
         - shell: |
             #!/bin/bash

--- a/jobs/kernel-f25-kt0.yml
+++ b/jobs/kernel-f25-kt0.yml
@@ -27,6 +27,7 @@
                 export JENKINS_JOB_NAME="${JOB_NAME}"
                 export JENKINS_BUILD_TAG="${BUILD_TAG}"
                 export ANSIBLE_HOST_KEY_CHECKING="False"
+            timeout: 36000
             playbook: sig-atomic-buildscripts/centos-ci/setup/setup-system.yml
     publishers:
         - ci-pipeline-duffy-publisher

--- a/jobs/ostree-compose.yml
+++ b/jobs/ostree-compose.yml
@@ -90,6 +90,7 @@
                 export JENKINS_JOB_NAME="${JOB_NAME}"
                 export JENKINS_BUILD_TAG="${BUILD_TAG}"
                 export OSTREE_BRANCH="${OSTREE_BRANCH:-}"
+            timeout: 3600
             playbook: sig-atomic-buildscripts/centos-ci/setup/setup-system.yml
         - inject:
             properties-file: ${WORKSPACE}/logs/ostree.props
@@ -168,6 +169,7 @@
                 export JENKINS_JOB_NAME="${JOB_NAME}"
                 export JENKINS_BUILD_TAG="${BUILD_TAG}"
                 export OSTREE_BRANCH="${OSTREE_BRANCH:-}"
+            timeout: 3600
             playbook: sig-atomic-buildscripts/centos-ci/setup/setup-system.yml
         - inject:
             properties-file: ${WORKSPACE}/logs/ostree.props
@@ -237,6 +239,7 @@
                 export JENKINS_BUILD_TAG="${BUILD_TAG}"
                 export OSTREE_BRANCH="${OSTREE_BRANCH:-}"
                 export ANSIBLE_HOST_KEY_CHECKING="False"
+            timeout: 3600
             playbook: sig-atomic-buildscripts/centos-ci/setup/setup-system.yml
     publishers:
         - ci-pipeline-duffy-publisher
@@ -327,6 +330,7 @@
                 export JENKINS_BUILD_TAG="${BUILD_TAG}"
                 export OSTREE_BRANCH="${OSTREE_BRANCH:-}"
                 export ANSIBLE_HOST_KEY_CHECKING="False"
+            timeout: 3600
             playbook: sig-atomic-buildscripts/centos-ci/setup/setup-system.yml
     publishers:
         - ci-pipeline-duffy-publisher

--- a/jobs/rpmbuild.yml
+++ b/jobs/rpmbuild.yml
@@ -99,6 +99,7 @@
                 export fed_repo="${fed_repo}"
                 export fed_branch="${fed_branch}"
                 export fed_rev="${fed_rev}"
+            timeout: 3600
             playbook: ci-pipeline/config/duffy-setup/setup-rpmbuild-system.yml
         - inject:
             properties-file: ${WORKSPACE}/logs/description.txt


### PR DESCRIPTION
The kernel ltp testing is getting ssh killed after ~6hours.  It needs longer to run.  This is the only timeout variable I could find in our provisioning so hopefully this fixes it.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>