### PR TITLE
Throttle concurrent rpmbuilds

### DIFF
--- a/jobs/rpmbuild.yml
+++ b/jobs/rpmbuild.yml
@@ -1,6 +1,12 @@
 - job:
     name: ci-pipeline-rpmbuild
     concurrent: true
+    properties:
+        - build-discarder:
+            num-to-keep: 30
+            artifact-num-to-keep: 15
+        - throttle:
+            max-total: 8
     defaults: ci-pipeline-defaults
     parameters:
         - string:


### PR DESCRIPTION
Concurrency helps keep the queue down, but even with 20 executors I'd rather not have ~15 rpmbuilds going at once.