### PR TITLE
Update atomic-host-tests ara generation

### DIFF
--- a/tasks/atomic-host-tests
+++ b/tasks/atomic-host-tests
@@ -35,7 +35,7 @@ function clean_up {
     ansible-playbook -i hosts ci-pipeline/playbooks/setup-libvirt-image.yml -l atomic_host_tests_slave -e 'state=absent'
     kill $(jobs -p)
     sudo rm -rf $tmpdir
-    ara generate junit - > $currentdir/logs/ansible_xunit.xml
+    ara generate junit - > ${HOMEDIR}/logs/ansible_xunit.xml
     rm -rf $HOME/.ara
 }
 trap clean_up EXIT SIGHUP SIGINT SIGTERM


### PR DESCRIPTION
07:05:56 + ara generate junit -
07:05:56 ./ci-pipeline/tasks/atomic-host-tests: line 38: /logs/ansible_xunit.xml: No such file or directory

Didn't dive in too deep, but I think this is the fix