### PR TITLE
Temporarily disable rsync locking

### DIFF
--- a/tasks/rpmbuild-test
+++ b/tasks/rpmbuild-test
@@ -27,30 +27,30 @@ fi
 mkdir ${RSYNC_BRANCH}
 mkdir repo
 # Write uuid to a lock file and store a backup
-uuidgen > file.lock
-cp file.lock uuid.saved
-while true; do
+#uuidgen > file.lock
+#cp file.lock uuid.saved
+#while true; do
      # Check if lock exists on remote server
-     while [[ $(rsync --ignore-existing --dry-run -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir) != *"file.lock"* ]]; do
-          sleep 60
-     done
-     cp uuid.saved file.lock
+#     while [[ $(rsync --ignore-existing --dry-run -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir) != *"file.lock"* ]]; do
+#          sleep 60
+#     done
+#     cp uuid.saved file.lock
      # Push lock file with uuid to remote server
-     rsync --ignore-existing -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/
+#     rsync --ignore-existing -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/
      # Pull lock file back
-     rsync -avz fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/file.lock file.lock
+#     rsync -avz fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/file.lock file.lock
      # If uuid matches, we can proceed
-     if [[ $(diff file.lock uuid.saved) == "" ]]; then
-          break
-     fi
-     sleep 60
-done
+#     if [[ $(diff file.lock uuid.saved) == "" ]]; then
+#          break
+#     fi
+#     sleep 60
+#done
 # Kill backgrounded jobs on exit
-function clean_up {
+#function clean_up {
      # Delete the rsync lock we placed
-     rsync -vr --delete $(mktemp -d)/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/
-}
-trap clean_up EXIT SIGHUP SIGINT SIGTERM
+#     rsync -vr --delete $(mktemp -d)/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/
+#}
+#trap clean_up EXIT SIGHUP SIGINT SIGTERM
 # Rsync the empty directories over first, then the repo directory
 rsync -arv ${RSYNC_BRANCH}/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic
 rsync -arv repo/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}


### PR DESCRIPTION
I think we should disable all the rsync locking stuff for now as we test out the ci-pipeline, as aborting a build messes up the locks [1].  We can turn them back on after, I don't see us running into problems with this turned off for now.

[1] Say a jenkins build starts a bash task on a duffy host.  If you abort the jenkins build, the duffy process is killed.  This allows the duffy host to be cleaned up as expected, but the duffy host's processes don't exit cleanly... so the bash task running on the duffy host doesn't get to run its traps.  So if you abort a build that pushed an rsync lock and hadn't yet deleted it, that lock is staying there and all future builds will hang until we go in and manually delete the lock.