### PR TITLE
Update Dockerfile for rpmbuild to f24

### DIFF
--- a/config/Dockerfiles/rpmbuild/Dockerfile
+++ b/config/Dockerfiles/rpmbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:25
+FROM fedora:24
 LABEL maintainer "https://github.com/CentOS-PaaS-SIG/ci-pipeline"
 LABEL description="This container is meant to \
 use fedpkg mock to create rpms."


### PR DESCRIPTION
Granted it is not the best solution, this seems to allow the rpmbuild container to advance past the error it has been getting since 3am July 4th.