### PR TITLE
Add dockerfile to run package level tests against an image

### DIFF
--- a/config/Dockerfiles/package_tests/image/Dockerfile
+++ b/config/Dockerfiles/package_tests/image/Dockerfile
@@ -1,0 +1,24 @@
+FROM fedora:25
+LABEL maintainer "https://github.com/CentOS-PaaS-SIG/ci-pipeline"
+LABEL description="This container is meant to \
+use upstreamfirst tests to test packages, \
+provided a package name and an image to test against."
+
+# Install all package requirements
+RUN for i in {1..5} ; do dnf -y install ansible \
+        curl \
+        findutils \
+        git \
+        sudo \
+        wget \
+        && dnf clean all \
+        && break || sleep 10 ; done
+
+# Copy the build script to the container
+COPY image_package_test.sh /home/image_package_test.sh
+
+# Run the build script
+ENTRYPOINT ["bash", "/home/image_package_test.sh"]
+
+# Call the container as follows:
+# docker run --privileged -v /dir/on/localhost/artifacts:/tmp/artifacts -t -i -e package=sed -e image_location=http://somewhere/image.qcow2 container_tag

--- a/config/Dockerfiles/package_tests/image/image_package_test.sh
+++ b/config/Dockerfiles/package_tests/image/image_package_test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Check if there is an upstream first repo for this package
+curl -s --head https://upstreamfirst.fedorainfracloud.org/${package} | head -n 1 | grep "HTTP/1.[01] [23].." > /dev/null
+if [ $? -ne 0 ]; then
+     echo "No upstream repo for this package! Exiting..."
+     exit 1
+fi
+# Clone jbieren fork of beakerlib role
+# Note: Once PR merged upstream, can just use upstream master
+git clone https://pagure.io/forks/jbieren/standard-test-roles.git
+pushd standard-test-roles
+git checkout beakerlib_atomic
+# Write test_cloud.yml file
+cat << EOF > test_cloud.yml
+---
+- hosts: localhost
+  vars:
+    artifacts: ./
+    playbooks: ./test_local.yml
+  vars_prompt:
+  - name: subjects
+    prompt: "A QCow2/raw test subject file"
+    private: no
+
+  roles:
+  - standard-test-cloud
+EOF
+# Write test_local.yml header
+cat << EOF > test_local.yml
+---
+- hosts: localhost
+  roles:
+  - role: standard-test-beakerlib
+    tests:
+EOF
+# Find the tests
+git clone https://upstreamfirst.fedorainfracloud.org/${package}
+for test in $(find ${package} -name "runtest.sh"); do
+     echo "    - $test" >> test_local.yml
+done
+# Execute the tests
+sudo ansible-playbook test_cloud.yml -e artifacts=/tmp/artifacts -e subjects=${image_location}
+exit $?


### PR DESCRIPTION
Provided an image, like the various qcow2 images the pipeline produces, this container will run all currently published package level testing on said image.  There is no need for a separate provisioner or anything, it is all taken care of in the container.  The one caveat is that the host the container runs from must have the kernel kvm modules.

Still a work in progress creating a second container which takes an ansible inventory as input instead of an image to run testing.  Getting hung up on the ansible local connection stuff from inside the container; it will come as a separate PR.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>