### PR TITLE
Add docker container to run package level testing against an ansible host

### DIFF
--- a/config/Dockerfiles/package_tests/ansible/Dockerfile
+++ b/config/Dockerfiles/package_tests/ansible/Dockerfile
@@ -1,0 +1,32 @@
+FROM fedora:25
+LABEL maintainer "https://github.com/CentOS-PaaS-SIG/ci-pipeline"
+LABEL description="This container is meant to \
+use upstreamfirst tests to test packages, \
+provided a package name and an ansible inventory."
+
+# Get repo for restraint-rhts
+ADD https://copr.fedorainfracloud.org/coprs/bpeck/restraint/repo/fedora-25/bpeck-restraint-fedora-25.repo /etc/yum.repos.d/
+
+# Install all package requirements
+RUN for i in {1..5} ; do dnf -y install ansible \
+        beakerlib \
+        curl \
+        findutils \
+        git \
+        restraint-rhts \
+        sed \
+        sudo \
+        && dnf clean all \
+        && break || sleep 10 ; done
+
+# Copy the build script to the container
+COPY ansible_package_test.sh /home/ansible_package_test.sh
+
+# Run the build script
+ENTRYPOINT ["bash", "/home/ansible_package_test.sh"]
+
+# Call the container as follows:
+# Note: foo below is some dir on localhost that contains both
+# your ansible inventory file AND the ansible ssh private key.
+# This is also the dir where the artifacts will be rsynced to
+# docker run --privileged -v /foo:/tmp -t -i -e package=sed container_tag

--- a/config/Dockerfiles/package_tests/ansible/ansible_package_test.sh
+++ b/config/Dockerfiles/package_tests/ansible/ansible_package_test.sh
@@ -10,11 +10,9 @@ if [ $? -ne 0 ]; then
      echo "No upstream repo for this package! Exiting..."
      exit 1
 fi
-# Clone jbieren fork of beakerlib role
-# Note: Once PR merged upstream, can just use upstream master
-git clone https://pagure.io/forks/jbieren/standard-test-roles.git
+# Clone standard-test-roles repo
+git clone https://pagure.io/standard-test-roles.git
 pushd standard-test-roles
-git checkout beakerlib_atomic
 # Write test_atomic.yml header
 cat << EOF > test_atomic.yml
 ---
@@ -25,6 +23,10 @@ cat << EOF > test_atomic.yml
 EOF
 # Find the tests
 git clone https://upstreamfirst.fedorainfracloud.org/${package}
+if [ $(find ${package} -name "runtest.sh" | wc -l) -eq 0 ]; then
+     echo "No runtest.sh files found in package's repo. Exiting..."
+     exit 1
+fi
 for test in $(find ${package} -name "runtest.sh"); do
      echo "    - $test" >> test_atomic.yml
 done

--- a/config/Dockerfiles/package_tests/ansible/ansible_package_test.sh
+++ b/config/Dockerfiles/package_tests/ansible/ansible_package_test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script requires that the docker run mounts the artifacts
+# dir to /tmp/artifacts, the ansible inventory file to /tmp/inventory,
+# and the ssh private key to /tmp/ssh_key
+
+# Check if there is an upstream first repo for this package
+curl -s --head https://upstreamfirst.fedorainfracloud.org/${package} | head -n 1 | grep "HTTP/1.[01] [23].." > /dev/null
+if [ $? -ne 0 ]; then
+     echo "No upstream repo for this package! Exiting..."
+     exit 1
+fi
+# Clone jbieren fork of beakerlib role
+# Note: Once PR merged upstream, can just use upstream master
+git clone https://pagure.io/forks/jbieren/standard-test-roles.git
+pushd standard-test-roles
+git checkout beakerlib_atomic
+# Write test_atomic.yml header
+cat << EOF > test_atomic.yml
+---
+- hosts: all
+  roles:
+  - role: standard-test-beakerlib
+    tests:
+EOF
+# Find the tests
+git clone https://upstreamfirst.fedorainfracloud.org/${package}
+for test in $(find ${package} -name "runtest.sh"); do
+     echo "    - $test" >> test_atomic.yml
+done
+# Get ready to execute tests
+sed -i 's|^artifacts\:.*|artifacts\: /tmp/artifacts|' roles/standard-test-beakerlib/vars/main.yml
+# Execute the tests
+export ANSIBLE_HOST_KEY_CHECKING=False
+ansible-playbook -i /tmp/inventory --private-key=/tmp/ssh_key --start-at-task='Define remote_artifacts if it is not already defined' test_atomic.yml
+exit $?

--- a/config/Dockerfiles/package_tests/image/image_package_test.sh
+++ b/config/Dockerfiles/package_tests/image/image_package_test.sh
@@ -6,11 +6,9 @@ if [ $? -ne 0 ]; then
      echo "No upstream repo for this package! Exiting..."
      exit 1
 fi
-# Clone jbieren fork of beakerlib role
-# Note: Once PR merged upstream, can just use upstream master
-git clone https://pagure.io/forks/jbieren/standard-test-roles.git
+# Clone standard-test-roles repo
+git clone https://pagure.io/standard-test-roles.git
 pushd standard-test-roles
-git checkout beakerlib_atomic
 # Write test_cloud.yml file
 cat << EOF > test_cloud.yml
 ---
@@ -36,6 +34,10 @@ cat << EOF > test_local.yml
 EOF
 # Find the tests
 git clone https://upstreamfirst.fedorainfracloud.org/${package}
+if [ $(find ${package} -name "runtest.sh" | wc -l) -eq 0 ]; then
+     echo "No runtest.sh files found in package's repo. Exiting..."
+     exit 1
+fi
 for test in $(find ${package} -name "runtest.sh"); do
      echo "    - $test" >> test_local.yml
 done

--- a/tasks/rpmbuild-test
+++ b/tasks/rpmbuild-test
@@ -14,7 +14,7 @@ which docker
 if [ "$?" != 0 ]; then echo "ERROR: DOCKER NOT INSTALLED\nSTATUS: $?"; exit 1; fi
 # Only build if it is not built already
 sudo systemctl start docker
-if [ "$(sudo docker ps -a | grep rpmbuild-container)" == "" ]; then sudo docker build -t rpmbuild-container . ; fi
+if [ "$(sudo docker images | grep rpmbuild-container)" == "" ]; then sudo docker build -t rpmbuild-container . ; fi
 sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/${fed_repo}/output:/home/${fed_repo}/output -v ${HOMEDIR}/${fed_repo}/rpmbuild:/home/rpmbuild -t -i -e fed_repo="${fed_repo}" -e fed_branch="${fed_branch}" -e fed_rev="${fed_rev}" rpmbuild-container
 popd
 # Move logs to location which can be rsynced


### PR DESCRIPTION
This container takes in an inventory file and a private key as inputs and runs package level testing against the ansible host.  It is set up to require both the ssh private key and the inventory file to be in the same directory on the host it is called from.  It also writes the artifacts out to that same directory.

Also fixes a small check in the rpmbuild task for deciding whether or not to build the image that Bill pointed out.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>