### PR TITLE
Allow rsync_opts to be passed to the rsync container, but default to --delete

### DIFF
--- a/config/Dockerfiles/rsync/rsync.sh
+++ b/config/Dockerfiles/rsync/rsync.sh
@@ -6,6 +6,10 @@ set -x
 #rsync_from="fedora-atomic@artifacts.ci.centos.org::fedora-atomic/f26/"
 #rsync_to="/home/output/"
 
+if [[ ! -v rsync_opts ]]; then
+    rsync_opts="--delete"
+fi
+
 for v in $rsync_paths; do
-    rsync --delete --stats -a ${rsync_from}${v}/ ${rsync_to}${v}/
+    rsync ${rsync_opts} --stats -a ${rsync_from}${v}/ ${rsync_to}${v}/
 done


### PR DESCRIPTION
Signed-off-by: Johnny Bieren <jbieren@redhat.com>