### PR TITLE
Make the rpmbuild task more containerized

### DIFF
--- a/tasks/rpmbuild-test
+++ b/tasks/rpmbuild-test
@@ -1,69 +1,86 @@
 #!/bin/bash
 set +e
 
-base_dir="$(dirname $0)/.."
+function acquire_lock {
+     # Write uuid to a lock file and store a backup
+     uuidgen > file.lock
+     cp file.lock uuid.saved
+     while true; do
+          # Check if lock exists on remote server
+          while [[ $(rsync --ignore-existing --dry-run -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/repo/lockdir) != *"file.lock"* ]]; do
+               sleep 60
+          done
+          cp uuid.saved file.lock
+          # Push lock file with uuid to remote server
+          rsync --ignore-existing -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/repo/lockdir/
+          # Pull lock file back
+          rsync -avz fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/repo/lockdir/file.lock file.lock
+          # If uuid matches, we can proceed
+          if [[ $(diff file.lock uuid.saved) == "" ]]; then
+               break
+          fi
+          sleep 60
+     done
+}
 
+# Kill backgrounded jobs on exit
+function clean_up {
+     # Delete the rsync lock we placed
+     rsync -vr --delete $(mktemp -d)/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/repo/lockdir/
+}
+#trap clean_up EXIT SIGHUP SIGINT SIGTERM
+
+base_dir="$(dirname $0)/.."
 HOMEDIR=$(pwd)
 rm -rf ${HOMEDIR}/${fed_repo}/output
 mkdir -p ${HOMEDIR}/${fed_repo}/output
 rm -rf ${HOMEDIR}/${fed_repo}/rpmbuild
 mkdir -p ${HOMEDIR}/${fed_repo}/rpmbuild
-pushd $base_dir/config/Dockerfiles/rpmbuild
-# Install docker
 which docker
 if [ "$?" != 0 ]; then echo "ERROR: DOCKER NOT INSTALLED\nSTATUS: $?"; exit 1; fi
-# Only build if it is not built already
 sudo systemctl start docker
-if [ "$(sudo docker images | grep rpmbuild-container)" == "" ]; then sudo docker build -t rpmbuild-container . ; fi
-sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/${fed_repo}/output:/home/${fed_repo}/output -v ${HOMEDIR}/${fed_repo}/rpmbuild:/home/rpmbuild -t -i -e fed_repo="${fed_repo}" -e fed_branch="${fed_branch}" -e fed_rev="${fed_rev}" rpmbuild-container
-popd
-# Move logs to location which can be rsynced
-cp -rp ${HOMEDIR}/${fed_repo}/output/logs ${HOMEDIR}
-# Find out RSYNC_BRANCH name so we can rsync over an empty repo if it DNE
-RSYNC_BRANCH=${fed_branch}
-if [ "${fed_branch}" = "master" ]; then
-    RSYNC_BRANCH=rawhide
-fi
-mkdir ${RSYNC_BRANCH}
-mkdir repo
-# Write uuid to a lock file and store a backup
-#uuidgen > file.lock
-#cp file.lock uuid.saved
-#while true; do
-     # Check if lock exists on remote server
-#     while [[ $(rsync --ignore-existing --dry-run -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir) != *"file.lock"* ]]; do
-#          sleep 60
-#     done
-#     cp uuid.saved file.lock
-     # Push lock file with uuid to remote server
-#     rsync --ignore-existing -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/
-     # Pull lock file back
-#     rsync -avz fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/file.lock file.lock
-     # If uuid matches, we can proceed
-#     if [[ $(diff file.lock uuid.saved) == "" ]]; then
-#          break
-#     fi
-#     sleep 60
-#done
-# Kill backgrounded jobs on exit
-#function clean_up {
-     # Delete the rsync lock we placed
-#     rsync -vr --delete $(mktemp -d)/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/
-#}
-#trap clean_up EXIT SIGHUP SIGINT SIGTERM
-# Rsync the empty directories over first, then the repo directory
-rsync -arv ${RSYNC_BRANCH}/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic
-rsync -arv repo/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}
-rsync --delete --stats -a ${HOMEDIR}/${fed_repo}/output/${fed_repo}_repo fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo
-if [ "$?" != 0 ]; then echo "ERROR: RSYNC REPO\nSTATUS: $?"; exit 1; fi
-rm -rf ${RSYNC_BRANCH}
-rm -rf repo
-# Update repo manifest file on artifacts.ci.centos.org
-rsync --delete --stats -a fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/manifest.txt .
-# Remove repo name from file if it exists so it isn't there twice
-sed -i "/${fed_repo}_repo/d" manifest.txt
-echo "${fed_repo}_repo $(date --utc +%FT%T%Z)" >> manifest.txt
-sort manifest.txt -o manifest.txt
-rsync --delete -stats -a manifest.txt fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo
 
+# Build the containers
+if [ "$(sudo docker images | grep rpmbuild-container)" == "" ]; then
+     pushd $base_dir/config/Dockerfiles/rpmbuild
+     sudo docker build -t rpmbuild-container .
+     popd
+fi
+if [ "$(sudo docker images | grep rsync-container)" == "" ]; then
+     pushd $base_dir/config/Dockerfiles/rsync
+     sudo docker build -t rsync-container .
+     popd
+fi
+
+sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/${fed_repo}/output:/home/${fed_repo}/output -v ${HOMEDIR}/${fed_repo}/rpmbuild:/home/rpmbuild -t -i -e fed_repo="${fed_repo}" -e fed_branch="${fed_branch}" -e fed_rev="${fed_rev}" rpmbuild-container
+# Move logs to proper location for duffy host cleanup rsync
+cp -rp ${HOMEDIR}/${fed_repo}/output/logs ${HOMEDIR}
+
+# Find out branch to rsync to
+if [ "${fed_branch}" = "master" ]; then
+    fed_branch=rawhide
+fi
+
+# Create empty branch and repo dirs to rsync over first in case they DNE
+mkdir -p ${HOMEDIR}/${fed_branch}/repo
+#acquire_lock
+
+# Get manifest file
+touch ${HOMEDIR}/${fed_branch}/repo/manifest.txt
+sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/${fed_branch}:/home/output -e rsync_paths="repo" -e rsync_from="fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/" -e rsync_to="/home/output/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" -e rsync_opts="--delete --existing" rsync-container
+
+# Update manifest file for latest change to package
+sudo sed -i "/${fed_repo}_repo/d" ${HOMEDIR}/${fed_branch}/repo/manifest.txt
+sudo sh -c "echo \"${fed_repo}_repo $(date --utc +%FT%T%Z)\" >> ${HOMEDIR}/${fed_branch}/repo/manifest.txt"
+sudo sort ${HOMEDIR}/${fed_branch}/repo/manifest.txt -o ${HOMEDIR}/${fed_branch}/repo/manifest.txt
+cat ${HOMEDIR}/${fed_branch}/repo/manifest.txt
+
+# Rsync empty dirs and manifest file back
+sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}:/home/output -e rsync_paths="${fed_branch} ${fed_branch}/repo" -e rsync_from="/home/output/" -e rsync_to="fedora-atomic@artifacts.ci.centos.org::fedora-atomic/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" -e rsync_opts="" rsync-container
+sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}:/home/output -e rsync_paths="${fed_branch}/repo/" -e rsync_from="/home/output/" -e rsync_to="fedora-atomic@artifacts.ci.centos.org::fedora-atomic/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" -e rsync_opts="--existing" rsync-container
+
+# Rsync over the rpms.  Needs different mount and rsync_to so has its own docker run
+sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/${fed_repo}/output:/home/output -e rsync_paths="${fed_repo}_repo" -e rsync_from="/home/output/" -e rsync_to="fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/repo/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" -e rsync_opts="--delete" rsync-container
+
+sudo rm -rf ${HOMEDIR}/${fed_branch}
 exit 0


### PR DESCRIPTION
Granted it is a lot of docker runs, this is a more containerized way to run the rpmbuild task.  Mostly I just containerized the rsync steps.  The locking is still commented out.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>