### PR TITLE
Make rpmbuild trigger concurrent

### DIFF
--- a/jobs/rpmbuild_trigger.yml
+++ b/jobs/rpmbuild_trigger.yml
@@ -1,5 +1,6 @@
 - job-template:
     name: ci-pipeline-rpmbuild-trigger
+    concurrent: true
     defaults: ci-pipeline-defaults
     triggers:
       - jms-messaging:


### PR DESCRIPTION
Until the old pipeline is 100% deprecated, we need the trigger to allow concurrency in case of rebuilds where 2000+ changes come rapidly, similar to this morning.