### PR TITLE
Take advantage of test_local.yml files if they are provided

### DIFF
--- a/config/Dockerfiles/package_tests/ansible/ansible_package_test.sh
+++ b/config/Dockerfiles/package_tests/ansible/ansible_package_test.sh
@@ -13,6 +13,7 @@ fi
 # Clone standard-test-roles repo
 git clone https://pagure.io/standard-test-roles.git
 pushd standard-test-roles
+git clone https://upstreamfirst.fedorainfracloud.org/${package}
 if [ -f ${package}/test_local.yml ]; then
      sed 's/hosts: localhost/hosts: all/' ${package}/test_local.yml > test_atomic.yml
 else
@@ -25,7 +26,6 @@ else
     tests:
 EOF
      # Find the tests
-     git clone https://upstreamfirst.fedorainfracloud.org/${package}
      if [ $(find ${package} -name "runtest.sh" | wc -l) -eq 0 ]; then
           echo "No runtest.sh files found in package's repo. Exiting..."
           exit 1

--- a/config/Dockerfiles/package_tests/image/image_package_test.sh
+++ b/config/Dockerfiles/package_tests/image/image_package_test.sh
@@ -15,7 +15,7 @@ cat << EOF > test_cloud.yml
 - hosts: localhost
   vars:
     artifacts: ./
-    playbooks: ./test_local.yml
+    playbooks: ./${package}/test_local.yml
   vars_prompt:
   - name: subjects
     prompt: "A QCow2/raw test subject file"
@@ -24,23 +24,25 @@ cat << EOF > test_cloud.yml
   roles:
   - standard-test-cloud
 EOF
-# Write test_local.yml header
-cat << EOF > test_local.yml
+if ! [ -f ${package}/test_local.yml ]; then
+     # Write test_local.yml header
+     cat << EOF > ${package}/test_local.yml
 ---
 - hosts: localhost
   roles:
   - role: standard-test-beakerlib
     tests:
 EOF
-# Find the tests
-git clone https://upstreamfirst.fedorainfracloud.org/${package}
-if [ $(find ${package} -name "runtest.sh" | wc -l) -eq 0 ]; then
-     echo "No runtest.sh files found in package's repo. Exiting..."
-     exit 1
+     # Find the tests
+     git clone https://upstreamfirst.fedorainfracloud.org/${package}
+     if [ $(find ${package} -name "runtest.sh" | wc -l) -eq 0 ]; then
+          echo "No runtest.sh files found in package's repo. Exiting..."
+          exit 1
+     fi
+     for test in $(find ${package} -name "runtest.sh"); do
+          echo "    - $test" >> ${package}/test_local.yml
+     done
 fi
-for test in $(find ${package} -name "runtest.sh"); do
-     echo "    - $test" >> test_local.yml
-done
 # Execute the tests
 sudo ansible-playbook test_cloud.yml -e artifacts=/tmp/artifacts -e subjects=${image_location}
 exit $?

--- a/config/Dockerfiles/package_tests/image/image_package_test.sh
+++ b/config/Dockerfiles/package_tests/image/image_package_test.sh
@@ -9,6 +9,7 @@ fi
 # Clone standard-test-roles repo
 git clone https://pagure.io/standard-test-roles.git
 pushd standard-test-roles
+git clone https://upstreamfirst.fedorainfracloud.org/${package}
 # Write test_cloud.yml file
 cat << EOF > test_cloud.yml
 ---
@@ -34,7 +35,6 @@ if ! [ -f ${package}/test_local.yml ]; then
     tests:
 EOF
      # Find the tests
-     git clone https://upstreamfirst.fedorainfracloud.org/${package}
      if [ $(find ${package} -name "runtest.sh" | wc -l) -eq 0 ]; then
           echo "No runtest.sh files found in package's repo. Exiting..."
           exit 1
@@ -43,6 +43,9 @@ EOF
           echo "    - $test" >> ${package}/test_local.yml
      done
 fi
+# Sym link ansible roles so they resolve properly
+mv /etc/ansible/roles /etc/ansible/roles-back
+ln -s $PWD/roles /etc/ansible/roles
 # Execute the tests
 sudo ansible-playbook test_cloud.yml -e artifacts=/tmp/artifacts -e subjects=${image_location}
 exit $?


### PR DESCRIPTION
Some packages have a test_local.yml file already provided, which is nice because it tells you the tests that exist.  The reason why that is nice is because some tests aren't named runtest.sh, so I would currently miss those.  So, this modification uses test_local.yml if it exists, instead of just making our own every time.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>