### PR TITLE
Add JAVA_GC_ARGS to Jenkins DeploymentConfig

### DIFF
--- a/config/s2i/jenkins/continuous-infra-jenkins-master-s2i-template.yaml
+++ b/config/s2i/jenkins/continuous-infra-jenkins-master-s2i-template.yaml
@@ -143,6 +143,11 @@ objects:
             value: 'true'
           - name: JNLP_SERVICE_NAME
             value: "${JNLP_SERVICE_NAME}"
+          - name: JAVA_GC_OPTS
+            value: >-
+                -XX:+UseParallelGC -XX:MaxPermSize=100m -XX:MinHeapFreeRatio=20
+                -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4
+                -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=500m
           resources:
             limits:
               memory: "${MEMORY_LIMIT}"


### PR DESCRIPTION
The default Jenkins image will add only 100m of Metaspace for the Java JVM
This is not enough since Groovy heavily uses the metaspace.