### PR TITLE
Add package level testing to ostree-boot task for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -495,6 +495,7 @@ node('fedora-atomic') {
                     // Rsync Data
                     writeFile file: "${env.ORIGIN_WORKSPACE}/task.env",
                               text: "export branch=\"${branch}\"\n" +
+                                    "export fed_repo=\"${fed_repo}\"\n" +
                                     "export image2boot=\"${image2boot}\"\n" +
                                     "export commit=\"${commit}\"\n" +
                                     "export JENKINS_JOB_NAME=\"${JOB_NAME}-${current_stage}\"\n" +

--- a/jobs/ostree-compose.yml
+++ b/jobs/ostree-compose.yml
@@ -243,6 +243,7 @@
             task: ostree-boot-image
             variables: |
                 export branch="${fed_branch}"
+                export fed_repo="${fed_repo}"
                 export image2boot="${image2boot:-}"
                 export commit=${commit:-}
                 export JENKINS_JOB_NAME="${JOB_NAME}"

--- a/tasks/ostree-boot-image
+++ b/tasks/ostree-boot-image
@@ -39,7 +39,7 @@ function clean_up {
     sudo rm -rf $tmpdir
     ara generate junit - > $currentdir/logs/ansible_xunit.xml
     rm -rf $HOME/.ara
-    cp $currentdir/packagevolume/artifacts $currentdir/logs
+    cp -rp $currentdir/packagevolume/artifacts $currentdir/logs
     rm -rf $currentdir/packagevolume
 }
 trap clean_up EXIT SIGHUP SIGINT SIGTERM

--- a/tasks/ostree-boot-image
+++ b/tasks/ostree-boot-image
@@ -118,7 +118,7 @@ cp inventory $currentdir/packagevolume
 cp ~/.ssh/id_rsa $currentdir/packagevolume/ssh_key
 
 # Run test
-sudo docker run --privileged -v $currentdir/packagevolume:/tmp -t -e package=$(fed_repo) package-test
+sudo docker run --privileged -v $currentdir/packagevolume:/tmp -t -e package=${fed_repo} package-test
 RUNTEST_STATUS=$?
 if [ "$RUNTEST_STATUS" != 0 ]; then
     echo -e "ERROR: RUNTEST\nSTATUS: $RUNTEST_STATUS"

--- a/tasks/ostree-boot-image
+++ b/tasks/ostree-boot-image
@@ -39,6 +39,8 @@ function clean_up {
     sudo rm -rf $tmpdir
     ara generate junit - > $currentdir/logs/ansible_xunit.xml
     rm -rf $HOME/.ara
+    cp $currentdir/packagevolume/artifacts $currentdir/logs
+    rm -rf $currentdir/packagevolume
 }
 trap clean_up EXIT SIGHUP SIGINT SIGTERM
 
@@ -105,3 +107,23 @@ if [ "$BOOT_STATUS" != 0 ]; then
     exit 1
 fi
 
+# Temporarily put package level test execution here
+pushd ci-pipeline/config/Dockerfiles/package_tests/ansible
+sudo docker build -t package-test .
+popd
+
+# Set up mounted volume
+mkdir $currentdir/packagevolume
+cp inventory $currentdir/packagevolume
+cp ~/.ssh/id_rsa $currentdir/packagevolume/ssh_key
+
+# Run test
+sudo docker run --privileged -v $currentdir/packagevolume:/tmp -t -e package=$(fed_repo) package-test
+RUNTEST_STATUS=$?
+if [ "$RUNTEST_STATUS" != 0 ]; then
+    echo -e "ERROR: RUNTEST\nSTATUS: $RUNTEST_STATUS"
+    #exit 1
+    # Still exit 0 so package level testing failure doesnt result in
+    # sending message saying failed to boot image
+    exit 0
+fi


### PR DESCRIPTION
We will want this to be its own job.  However, I think we should turn this on for now until we get there, so we can say we are running these tests in the pipeline.  In order for it to be its own job, we will have to modify the ostree-boot task to not tear down the host and to pass its inventory file and key along to the package testing task.  This would require not tearing down the duffy host as well.  But, we are moving to containers, so not sure what it means in that case.  So, since adding it cleanly is a little complicated for now, I think we should temporarily add it like this.  Once we have ostree-boot working in a container, we can worry about separating it out and defining the workflow for how the two work together.