### PR TITLE
Issue since ostree.props doesn't exist in certain runs

### DIFF
--- a/config/Dockerfiles/ostree_compose/ostree-compose.sh
+++ b/config/Dockerfiles/ostree_compose/ostree-compose.sh
@@ -13,6 +13,7 @@ fi
 REF="fedora/${branch}/x86_64/atomic-host"
 
 mkdir -p /home/output/logs
+touch /home/output/logs/ostree.props
 
 if [[ ! -e /home/output/ostree ]]; then
     mkdir /home/output/ostree


### PR DESCRIPTION
- touch /home/output/logs/ostree.props
- ex. of failure https://jenkins-continuous-infra.apps.ci.centos.org/job/ci-pipeline-f26/139/console