### PR TITLE
Improve rpmbuild container and have it do the rsync as well

### DIFF
--- a/config/Dockerfiles/rpmbuild/Dockerfile
+++ b/config/Dockerfiles/rpmbuild/Dockerfile
@@ -1,7 +1,8 @@
 FROM fedora:24
 LABEL maintainer "https://github.com/CentOS-PaaS-SIG/ci-pipeline"
 LABEL description="This container is meant to \
-use fedpkg mock to create rpms."
+use fedpkg mock to create rpms.  It also rsyncs \
+them to artifacts.ci.centos.org."
 
 # Install all package requirements
 RUN for i in {1..5} ; do dnf -y update && dnf clean all && break || sleep 10 ; done
@@ -39,3 +40,5 @@ COPY rpmbuild-test.sh /home/rpmbuild-test.sh
 
 # Run the build script
 ENTRYPOINT ["bash", "/home/rpmbuild-test.sh"]
+# Run the container as follows
+# docker run --privileged -v /some/spot/for/logs:/home/logs -e fed_repo=${packagename} -e fed_branch=${fed_branch} -e fed_rev=${fed_rev} -e RSYNC_PASSWORD=${rsync_password} container_tag

--- a/config/Dockerfiles/rpmbuild/Dockerfile
+++ b/config/Dockerfiles/rpmbuild/Dockerfile
@@ -41,4 +41,4 @@ COPY rpmbuild-test.sh /home/rpmbuild-test.sh
 # Run the build script
 ENTRYPOINT ["bash", "/home/rpmbuild-test.sh"]
 # Run the container as follows
-# docker run --privileged -v /some/spot/for/logs:/home/logs -e fed_repo=${packagename} -e fed_branch=${fed_branch} -e fed_rev=${fed_rev} -e RSYNC_PASSWORD=${rsync_password} container_tag
+# docker run --privileged -v /some/spot/for/logs:/home/logs -e fed_repo=${packagename} -e fed_branch=${fed_branch} -e fed_rev=${fed_rev} -e enable_rsync=yes -e RSYNC_PASSWORD=${rsync_password} -e production=yes container_tag

--- a/config/Dockerfiles/rpmbuild/Dockerfile
+++ b/config/Dockerfiles/rpmbuild/Dockerfile
@@ -41,4 +41,5 @@ COPY rpmbuild-test.sh /home/rpmbuild-test.sh
 # Run the build script
 ENTRYPOINT ["bash", "/home/rpmbuild-test.sh"]
 # Run the container as follows
+# Note: For stage builds, don't do production=no, simply don't pass a production var in
 # docker run --privileged -v /some/spot/for/logs:/home/logs -e fed_repo=${packagename} -e fed_branch=${fed_branch} -e fed_rev=${fed_rev} -e enable_rsync=yes -e RSYNC_PASSWORD=${rsync_password} -e production=yes container_tag

--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -1,32 +1,28 @@
 #!/bin/bash
 set +e
 
-OUTPUTDIR=/home/${fed_repo}/output
-which fedpkg
-if [ "$?" != 0 ]; then echo "ERROR: FEDPKG RPM NOT INSTALLED\nSTATUS: $?"; exit 1; fi
-# Put all output files into logs/ for rsync
-rm -rf ${OUTPUTDIR}/logs
-mkdir ${OUTPUTDIR}/logs
+RPMDIR=/home/${fed_repo}_repo
+# Create one dir to store logs in that will be mounted
+LOGDIR=/home/logs
+rm -rf ${LOGDIR}/*
+mkdir -p ${LOGDIR}
 # Clone the fedoraproject git repo
 rm -rf ${fed_repo}
 fedpkg clone -a ${fed_repo}
-if [ "$?" != 0 ]; then echo "ERROR: FEDPKG CLONE\nSTATUS: $?"; exit 1; fi
+if [ "$?" != 0 ]; then echo -e "ERROR: FEDPKG CLONE\nSTATUS: $?"; exit 1; fi
 pushd ${fed_repo}
-# Checkout the proper branch
+# Checkout the proper branch, likely unneeded since we checkout commit anyways
 git checkout ${fed_branch}
 # Checkout the commit from the fedmsg
 git checkout ${fed_rev}
 # Create new branch because fedpkg wont build with detached head
 git checkout -b test_branch
-# Find number of git commits in log to append to RELEASE
+# Find number of git commits in log to append to RELEASE before %{?dist}
 commits=$(git log --pretty=format:'' | wc -l)
-# Append to release in spec file
-sed -i "/^Release:/s/\$/.${commits}.${fed_rev:0:7}/" ${fed_repo}.spec
+# Append to release in spec file before dist
+sed -i "/^Release:/s/%{?dist}/.${commits}.${fed_rev:0:7}%{?dist}/" ${fed_repo}.spec
 # fedpkg prep to unpack the tarball
 fedpkg --release ${fed_branch} prep
-# Make sure we have rpmspec before we call it
-which rpmspec
-if [ "$?" != 0 ]; then echo "ERROR: RPMSPEC RPM NOT INSTALLED\nSTATUS: $?"; exit 1; fi
 VERSION=$(rpmspec --queryformat "%{VERSION}\n" -q ${fed_repo}.spec | head -n 1)
 # Some packages are packagename-version-release, some packagename-sha, some packagename[0-9]
 DIR_TO_GO=$(find . -maxdepth 1 -type d | cut -c 3- | grep ${fed_repo})
@@ -34,21 +30,22 @@ pushd $DIR_TO_GO
 # Run configure if it exists, if not, no big deal
 ./configure
 # Run tests if they are there
-make test >> ${OUTPUTDIR}/logs/make_test_output.txt
+make test >> ${LOGDIR}/make_test_output.txt
 MAKE_TEST_STATUS=$?
 popd
 if [ "$MAKE_TEST_STATUS" == 2 ]; then
-     sudo echo "description='${fed_repo} - No tests'" >> ${OUTPUTDIR}/logs/description.txt
+     echo "description='${fed_repo} - No tests'" >> ${LOGDIR}/package_props.txt
 elif [ "$MAKE_TEST_STATUS" == 0 ]; then
-     sudo echo "description='${fed_repo} - make test passed'" >> ${OUTPUTDIR}/logs/description.txt
+     echo "description='${fed_repo} - make test passed'" >> ${LOGDIR}/package_props.txt
 else
-     sudo echo "description='${fed_repo} - make test failed'" >> ${OUTPUTDIR}/logs/description.txt
+     echo "description='${fed_repo} - make test failed'" >> ${LOGDIR}/package_props.txt
+     exit $MAKE_TEST_STATUS
 fi
 # Build the package into ./results_${fed_repo}/$VERSION/$RELEASE/
 fedpkg --release ${fed_branch} mockbuild
 MOCKBUILD_STATUS=$?
-sudo echo "status=$MOCKBUILD_STATUS" >> ${OUTPUTDIR}/logs/package_props.txt
-if [ "$MOCKBUILD_STATUS" != 0 ]; then echo "ERROR: FEDPKG MOCKBUILD\nSTATUS: $MOCKBUILD_STATUS"; exit 1; fi
+echo "status=$MOCKBUILD_STATUS" >> ${LOGDIR}/package_props.txt
+if [ "$MOCKBUILD_STATUS" != 0 ]; then echo -e "ERROR: FEDPKG MOCKBUILD\nSTATUS: $MOCKBUILD_STATUS"; exit 1; fi
 popd
 
 ABIGAIL_BRANCH=$(echo ${fed_branch} | sed 's/./&c/1')
@@ -56,19 +53,65 @@ if [ "${fed_branch}" = "master" ]; then
     ABIGAIL_BRANCH="fc27"
 fi
 # Make repo with the newly created rpm
-rm -rf ${OUTPUTDIR}/${fed_repo}_repo
-mkdir ${OUTPUTDIR}/${fed_repo}_repo
-cp ${fed_repo}/results_${fed_repo}/${VERSION}/*/*.rpm ${OUTPUTDIR}/${fed_repo}_repo/
+rm -rf ${RPMDIR}/*
+mkdir -p ${RPMDIR}
+cp ${fed_repo}/results_${fed_repo}/${VERSION}/*/*.rpm ${RPMDIR}/
 # Run rpmlint
-rpmlint ${OUTPUTDIR}/${fed_repo}_repo/ > ${OUTPUTDIR}/logs/rpmlint_out.txt
-pushd ${OUTPUTDIR}/${fed_repo}_repo && createrepo .
+rpmlint ${RPMDIR}/ > ${LOGDIR}/rpmlint_out.txt
+pushd ${RPMDIR} && createrepo .
 popd
 # Run fedabipkgdiff against the newly created rpm
 rm -rf libabigail
 git clone git://sourceware.org/git/libabigail.git
 RPM_TO_CHECK=$(find ${fed_repo}/results_${fed_repo}/${VERSION}/*/ -name "${fed_repo}-${VERSION}*" | grep -v src)
-libabigail/tools/fedabipkgdiff --from ${ABIGAIL_BRANCH} ${RPM_TO_CHECK} &> ${OUTPUTDIR}/logs/fedabipkgdiff_out.txt
+libabigail/tools/fedabipkgdiff --from ${ABIGAIL_BRANCH} ${RPM_TO_CHECK} &> ${LOGDIR}/fedabipkgdiff_out.txt
 RPM_NAME=$(basename $RPM_TO_CHECK)
-echo "package_url=http://artifacts.ci.centos.org/fedora-atomic/${fed_branch}/repo/${fed_repo}_repo/$RPM_NAME" >> ${OUTPUTDIR}/logs/package_props.txt
+echo "package_url=http://artifacts.ci.centos.org/fedora-atomic/${fed_branch}/repo/${fed_repo}_repo/$RPM_NAME" >> ${LOGDIR}/package_props.txt
 
-exit 0
+# Perform rsync to artifacts.ci.centos.org
+RSYNC_BRANCH=${fed_branch}
+if [ "${fed_branch}" = "master" ]; then
+    RSYNC_BRANCH=rawhide
+fi
+mkdir ${RSYNC_BRANCH}
+mkdir repo
+# Kill backgrounded jobs on exit
+function clean_up {
+    # Delete the rsync lock we placed
+     rsync -vr --delete $(mktemp -d)/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/
+}
+trap clean_up EXIT SIGHUP SIGINT SIGTERM
+# Write uuid to a lock file and store a backup
+uuidgen > file.lock
+cp file.lock uuid.saved
+while true; do
+    # Check if lock exists on remote server
+     while [[ $(rsync --ignore-existing --dry-run -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir) != *"file.lock"* ]]; do
+          sleep 60
+     done
+     cp uuid.saved file.lock
+    # Push lock file with uuid to remote server
+     rsync --ignore-existing -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/
+    # Pull lock file back
+     rsync -avz fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/lockdir/file.lock file.lock
+    # If uuid matches, we can proceed
+     if [[ $(diff file.lock uuid.saved) == "" ]]; then
+          break
+     fi
+     sleep 60
+done
+# Rsync the empty directories over first, then the repo directory
+rsync -arv ${RSYNC_BRANCH}/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic
+rsync -arv repo/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}
+rsync --delete --stats -a ${RPMDIR} fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo
+if [ "$?" != 0 ]; then echo "ERROR: RSYNC REPO\nSTATUS: $?"; exit 1; fi
+rm -rf ${RSYNC_BRANCH}
+rm -rf repo
+# Update repo manifest file on artifacts.ci.centos.org
+rsync --delete --stats -a fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo/manifest.txt .
+# Remove repo name from file if it exists so it isn't there twice
+sed -i "/${fed_repo}_repo/d" manifest.txt
+echo "${fed_repo}_repo $(date --utc +%FT%T%Z)" >> manifest.txt
+sort manifest.txt -o manifest.txt
+rsync --delete -stats -a manifest.txt fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${RSYNC_BRANCH}/repo
+clean_up

--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -82,7 +82,10 @@ RSYNC_BRANCH=${fed_branch}
 if [ "${fed_branch}" = "master" ]; then
     RSYNC_BRANCH=rawhide
 fi
-mkdir ${RSYNC_BRANCH}
+if [ -z "${production}" ]; then
+    RSYNC_BRANCH=${RSYNC_BRANCH}/staging
+fi
+mkdir -p ${RSYNC_BRANCH}
 mkdir repo
 # Kill backgrounded jobs on exit
 function clean_up {

--- a/tasks/rpmbuild-test
+++ b/tasks/rpmbuild-test
@@ -10,5 +10,5 @@ sudo systemctl start docker
 pushd $base_dir/config/Dockerfiles/rpmbuild
 sudo docker build -t rpmbuild-container .
 popd
-sudo docker run --privileged -v ${HOMEDIR}:/home/logs -e fed_repo="${fed_repo}" -e fed_branch="${fed_branch}" -e fed_rev="${fed_rev}" -e RSYNC_PASSWORD=${RSYNC_PASSWORD} rpmbuild-container
+sudo docker run --privileged -v ${HOMEDIR}:/home/logs -e fed_repo="${fed_repo}" -e fed_branch="${fed_branch}" -e fed_rev="${fed_rev}" -e enable_rsync=yes -e RSYNC_PASSWORD=${RSYNC_PASSWORD} -e production=yes rpmbuild-container
 if [ "$?" != 0 ]; then echo -e "ERROR: RPMBUILD FAILED\nSTATUS: $?"; exit 1; fi

--- a/tasks/rpmbuild-test
+++ b/tasks/rpmbuild-test
@@ -1,87 +1,14 @@
 #!/bin/bash
 set +e
 
-function acquire_lock {
-     # Write uuid to a lock file and store a backup
-     uuidgen > file.lock
-     cp file.lock uuid.saved
-     while true; do
-          # Check if lock exists on remote server
-          while [[ $(rsync --ignore-existing --dry-run -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/repo/lockdir) != *"file.lock"* ]]; do
-               sleep 60
-          done
-          cp uuid.saved file.lock
-          # Push lock file with uuid to remote server
-          rsync --ignore-existing -avz file.lock fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/repo/lockdir/
-          # Pull lock file back
-          rsync -avz fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/repo/lockdir/file.lock file.lock
-          # If uuid matches, we can proceed
-          if [[ $(diff file.lock uuid.saved) == "" ]]; then
-               break
-          fi
-          sleep 60
-     done
-}
-
-# Kill backgrounded jobs on exit
-function clean_up {
-     # Delete the rsync lock we placed
-     rsync -vr --delete $(mktemp -d)/ fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/repo/lockdir/
-}
-trap clean_up EXIT SIGHUP SIGINT SIGTERM
-
-base_dir="$(dirname $0)/.."
 HOMEDIR=$(pwd)
-rm -rf ${HOMEDIR}/${fed_repo}/output
-mkdir -p ${HOMEDIR}/${fed_repo}/output
-rm -rf ${HOMEDIR}/${fed_repo}/rpmbuild
-mkdir -p ${HOMEDIR}/${fed_repo}/rpmbuild
 which docker
 if [ "$?" != 0 ]; then echo "ERROR: DOCKER NOT INSTALLED\nSTATUS: $?"; exit 1; fi
 sudo systemctl start docker
 
-# Build the containers
-if [ "$(sudo docker images | grep rpmbuild-container)" == "" ]; then
-     pushd $base_dir/config/Dockerfiles/rpmbuild
-     sudo docker build -t rpmbuild-container .
-     popd
-fi
-if [ "$(sudo docker images | grep rsync-container)" == "" ]; then
-     pushd $base_dir/config/Dockerfiles/rsync
-     sudo docker build -t rsync-container .
-     popd
-fi
-
-sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/${fed_repo}/output:/home/${fed_repo}/output -v ${HOMEDIR}/${fed_repo}/rpmbuild:/home/rpmbuild -t -i -e fed_repo="${fed_repo}" -e fed_branch="${fed_branch}" -e fed_rev="${fed_rev}" rpmbuild-container
+# Build the container
+pushd $base_dir/config/Dockerfiles/rpmbuild
+sudo docker build -t rpmbuild-container .
+popd
+sudo docker run --privileged -v ${HOMEDIR}:/home/logs -e fed_repo="${fed_repo}" -e fed_branch="${fed_branch}" -e fed_rev="${fed_rev}" -e RSYNC_PASSWORD=${RSYNC_PASSWORD} rpmbuild-container
 if [ "$?" != 0 ]; then echo -e "ERROR: RPMBUILD FAILED\nSTATUS: $?"; exit 1; fi
-# Move logs to proper location for duffy host cleanup rsync
-cp -rp ${HOMEDIR}/${fed_repo}/output/logs ${HOMEDIR}
-
-# Find out branch to rsync to
-if [ "${fed_branch}" = "master" ]; then
-    fed_branch=rawhide
-fi
-
-# Create empty branch and repo dirs to rsync over first in case they DNE
-mkdir -p ${HOMEDIR}/${fed_branch}/repo
-acquire_lock
-
-# Get manifest file
-touch ${HOMEDIR}/${fed_branch}/repo/manifest.txt
-sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/${fed_branch}:/home/output -e rsync_paths="repo" -e rsync_from="fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/" -e rsync_to="/home/output/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" -e rsync_opts="--delete --existing" rsync-container
-
-# Update manifest file for latest change to package
-sudo sed -i "/${fed_repo}_repo/d" ${HOMEDIR}/${fed_branch}/repo/manifest.txt
-sudo sh -c "echo \"${fed_repo}_repo $(date --utc +%FT%T%Z)\" >> ${HOMEDIR}/${fed_branch}/repo/manifest.txt"
-sudo sort ${HOMEDIR}/${fed_branch}/repo/manifest.txt -o ${HOMEDIR}/${fed_branch}/repo/manifest.txt
-cat ${HOMEDIR}/${fed_branch}/repo/manifest.txt
-
-# Rsync empty dirs and manifest file back
-sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}:/home/output -e rsync_paths="${fed_branch} ${fed_branch}/repo" -e rsync_from="/home/output/" -e rsync_to="fedora-atomic@artifacts.ci.centos.org::fedora-atomic/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" -e rsync_opts="" rsync-container
-sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}:/home/output -e rsync_paths="${fed_branch}/repo/" -e rsync_from="/home/output/" -e rsync_to="fedora-atomic@artifacts.ci.centos.org::fedora-atomic/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" -e rsync_opts="--existing" rsync-container
-
-# Rsync over the rpms.  Needs different mount and rsync_to so has its own docker run
-sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/${fed_repo}/output:/home/output -e rsync_paths="${fed_repo}_repo" -e rsync_from="/home/output/" -e rsync_to="fedora-atomic@artifacts.ci.centos.org::fedora-atomic/${fed_branch}/repo/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" -e rsync_opts="--delete" rsync-container
-
-sudo rm -rf ${HOMEDIR}/${fed_branch}
-exit 0


### PR DESCRIPTION
These changes to the rpmbuild container are meant to make the migration into OpenShift easier.  I put the rsync aspects of the rpmbuild flow into the container so it is all one container call.  It will still exit before going near any rsync stuff if make test fails or any of the rpmbuild stuff fails.  No changes should be needed in the Jenkinsfile, as no additional arguments are needed and it is still just a call to the duffy builder with the same task.  I made all the changes in the task file and container config so it should *just work.*  

Once approved, I will merge it when I am going to be online for a bit so I can monitor it to make sure I didn't break anything.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>