### PR TITLE
removing the output dir was really just to clear the logs

### DIFF
--- a/tasks/ostree-compose
+++ b/tasks/ostree-compose
@@ -10,7 +10,8 @@ HOMEDIR=$(pwd)
 # Make sure logs are empty so we don't report previous build
 # if we fail
 if [ -e "${HOMEDIR}/output/logs" ]; then
-    sudo rm -rf ${HOMEDIR}/output/logs
+    sudo rm -rf ${HOMEDIR}/output/logs >/dev/null 2>&1
+    echo "rm -rf ${HOMEDIR}/output/logs rc:$?"
 fi
 mkdir -p ${HOMEDIR}/output
 

--- a/tasks/ostree-compose
+++ b/tasks/ostree-compose
@@ -6,7 +6,12 @@ fi
 
 base_dir="$(dirname $0)/.."
 HOMEDIR=$(pwd)
-rm -rf ${HOMEDIR}/output
+
+# Make sure logs are empty so we don't report previous build
+# if we fail
+if [ -e "${HOMEDIR}/output/logs" ]; then
+    sudo rm -rf ${HOMEDIR}/output/logs
+fi
 mkdir -p ${HOMEDIR}/output
 
 pushd $base_dir/config/Dockerfiles/rsync


### PR DESCRIPTION
from the previous run.  So just delete the logs and it must be
done via sudo because the containers run privileged.