### PR TITLE
trigger job: add f27

### DIFF
--- a/jobs/rpmbuild_trigger.yml
+++ b/jobs/rpmbuild_trigger.yml
@@ -114,6 +114,6 @@
 - project:
     name: ci-pipeline-rpmbuild-trigger-jobs
     repo-name: ci-pipeline
-    targets: '^(f25|f26|master)$'
+    targets: '^(f25|f26|f27|master)$'
     jobs:
       - ci-pipeline-rpmbuild-trigger


### PR DESCRIPTION
We were looking for `master` but comparing it to `rawhide`. Also add f27
now that dist-git branched.