### PR TITLE
More substitution needed in fedmsg_fields.txt

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,7 @@ podTemplate(name: 'fedora-atomic-inline', label: 'fedora-atomic-inline', cloud: 
                         if [ -n "${CI_MESSAGE}" ]; then
                             echo ${CI_MESSAGE} | ${WORKSPACE}/parse_fedmsg.py > fedmsg_fields.txt
                             sed -i '/^\\\\s*$/d' ${WORKSPACE}/fedmsg_fields.txt
+                            sed -i '/`/g' ${WORKSPACE}/fedmsg_fields.txt
                             sed -i '/^fed/!d' ${WORKSPACE}/fedmsg_fields.txt
                             grep fed ${WORKSPACE}/fedmsg_fields.txt > ${WORKSPACE}/fedmsg_fields.txt.tmp
                             mv ${WORKSPACE}/fedmsg_fields.txt.tmp ${WORKSPACE}/fedmsg_fields.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,7 @@ podTemplate(name: 'fedora-atomic-inline', label: 'fedora-atomic-inline', cloud: 
                             echo ${CI_MESSAGE} | ${WORKSPACE}/parse_fedmsg.py > fedmsg_fields.txt
                             sed -i '/^\\\\s*$/d' ${WORKSPACE}/fedmsg_fields.txt
                             sed -i '/`/g' ${WORKSPACE}/fedmsg_fields.txt
+                            sed -i '/^fed/!d\' ${WORKSPACE}/fedmsg_fields.txt
                             grep fed ${WORKSPACE}/fedmsg_fields.txt > ${WORKSPACE}/fedmsg_fields.txt.tmp
                             mv ${WORKSPACE}/fedmsg_fields.txt.tmp ${WORKSPACE}/fedmsg_fields.txt
                         fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,8 +84,7 @@ podTemplate(name: 'fedora-atomic-inline', label: 'fedora-atomic-inline', cloud: 
                         if [ -n "${CI_MESSAGE}" ]; then
                             echo ${CI_MESSAGE} | ${WORKSPACE}/parse_fedmsg.py > fedmsg_fields.txt
                             sed -i '/^\\\\s*$/d' ${WORKSPACE}/fedmsg_fields.txt
-                            sed -i '/`/g' ${WORKSPACE}/fedmsg_fields.txt
-                            sed -i '/^fed/!d\' ${WORKSPACE}/fedmsg_fields.txt
+                            sed -i '/^fed/!d' ${WORKSPACE}/fedmsg_fields.txt
                             grep fed ${WORKSPACE}/fedmsg_fields.txt > ${WORKSPACE}/fedmsg_fields.txt.tmp
                             mv ${WORKSPACE}/fedmsg_fields.txt.tmp ${WORKSPACE}/fedmsg_fields.txt
                         fi


### PR DESCRIPTION
- This caused a recent failure
  https://jenkins-continuous-infra.apps.ci.centos.org/job/continuous-infra-ci-pipeline-f26/36/console
- We should just throw out anything that doesn't start with
  ^fed since we don't need this issue