### PR TITLE
UPDATE python file to parse and write groovy props

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,9 @@ podTemplate(name: 'fedora-atomic-inline', label: 'fedora-atomic-inline', cloud: 
                         env.image2boot = env.image2boot ?: ''
                         env.image_name = env.image_name ?: ''
                         env.FEDORA_PRINCIPAL = env.FEDORA_PRINCIPAL ?: 'bpeck/jenkins-continuous-infra.apps.ci.centos.org@FEDORAPROJECT.ORG'
+                        env.package_url = env.package_url ?: ''
+                        env.nvr = env.nvr ?: ''
+                        env.original_spec_nvr = env.original_spec_nvr ?: ''
 
                         // SCM
                         dir('ci-pipeline') {
@@ -93,6 +96,7 @@ podTemplate(name: 'fedora-atomic-inline', label: 'fedora-atomic-inline', cloud: 
                     sed -i '/^\\\\s*$/d' ${WORKSPACE}/fedmsg_fields.txt
                     sed -i '/`/g' ${WORKSPACE}/fedmsg_fields.txt
                     sed -i '/^fed/!d' ${WORKSPACE}/fedmsg_fields.txt
+                    sed -i 's/"//g' ${WORKSPACE}/fedmsg_fields.txt
                     grep fed ${WORKSPACE}/fedmsg_fields.txt > ${WORKSPACE}/fedmsg_fields.txt.tmp
                     mv ${WORKSPACE}/fedmsg_fields.txt.tmp ${WORKSPACE}/fedmsg_fields.txt
                 fi
@@ -690,23 +694,25 @@ podTemplate(name: 'fedora-atomic-inline', label: 'fedora-atomic-inline', cloud: 
                     currentBuild.displayName = "Build#: ${env.BUILD_NUMBER} - Branch: ${env.branch} - Package: ${env.fed_repo}"
                     currentBuild.description = "${currentBuild.currentResult}"
                     //emailext subject: "${env.JOB_NAME} - Build # ${env.BUILD_NUMBER} - STATUS = ${currentBuild.currentResult}", to: "ari@redhat.com", body: "This pipeline was a ${currentBuild.currentResult}"
-                    step([$class: 'ArtifactArchiver', allowEmptyArchive: true, artifacts: '**/logs/**,*.txt,*.groovy,**/job.*,**/*.groovy,**/inventory.*', excludes: '**/*.example', fingerprint: true])
+                    step([$class: 'ArtifactArchiver', allowEmptyArchive: true, artifacts: '**/logs/**,*.txt,*.groovy,**/job.*,**/*.groovy,**/inventory.*', excludes: '**/job.props,**/job.props.groovy,**/*.example', fingerprint: true])
 
                     // Send message org.centos.prod.ci.pipeline.complete on fedmsg
-                    env.topic = "${env.MAIN_TOPIC}.ci.pipeline.complete"
-                    messageProperties = "topic=${topic}\n" +
-                            "build_url=${BUILD_URL}\n" +
-                            "build_id=${BUILD_ID}\n" +
-                            "branch=${branch}\n" +
-                            "ref=fedora/${branch}/${basearch}/atomic-host\n" +
-                            "rev=${fed_rev}\n" +
-                            "repo=${fed_repo}\n" +
-                            "namespace=${fed_namespace}\n" +
-                            "username=fedora-atomic\n" +
-                            "test_guidance=''\n" +
-                            "status=${currentBuild.currentResult}"
-                    messageContent = ''
-                    sendMessage(messageProperties, messageContent)
+//                    env.topic = "${env.MAIN_TOPIC}.ci.pipeline.complete"
+//                    messageProperties = "topic=${topic}\n" +
+//                            "build_url=${BUILD_URL}\n" +
+//                            "build_id=${BUILD_ID}\n" +
+//                            "branch=${branch}\n" +
+//                            "original_spec_nvr=${original_spec_nvr}\n" +
+//                            "nvr=${nvr}\n" +
+//                            "ref=fedora/${branch}/${basearch}/atomic-host\n" +
+//                            "rev=${fed_rev}\n" +
+//                            "repo=${fed_repo}\n" +
+//                            "namespace=${fed_namespace}\n" +
+//                            "username=fedora-atomic\n" +
+//                            "test_guidance=''\n" +
+//                            "status=${currentBuild.currentResult}"
+//                    messageContent = ''
+//                    sendMessage(messageProperties, messageContent)
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,41 +71,26 @@ podTemplate(name: 'fedora-atomic-inline', label: 'fedora-atomic-inline', cloud: 
 
                         // Python script to parse the ${CI_MESSAGE}
                         writeFile file: "${env.WORKSPACE}/parse_fedmsg.py",
-                                text: "#!/bin/env python\n" +
+                                text: "#! /usr/bin/env python\n" +
+                                        "\n" +
                                         "import json\n" +
-                                        "import sys\n\n" +
-                                        "reload(sys)\n" +
-                                        "sys.setdefaultencoding('utf-8')\n" +
-                                        "message = json.load(sys.stdin)\n" +
-                                        "if 'commit' in message:\n" +
-                                        "    msg = message['commit']\n\n" +
-                                        "    for key in msg:\n" +
-                                        "        safe_key = key.replace('-', '_')\n" +
-                                        "        print \"fed_%s=%s\" % (safe_key, msg[key])\n"
-
-                        // Parse the ${CI_MESSAGE}
-                        sh '''
-                #!/bin/bash
-                set -xuo pipefail
-
-                chmod +x ${WORKSPACE}/parse_fedmsg.py
-
-                # Write fedmsg fields to a file to inject them
-                if [ -n "${CI_MESSAGE}" ]; then
-                    echo ${CI_MESSAGE} | ${WORKSPACE}/parse_fedmsg.py > fedmsg_fields.txt
-                    sed -i '/^\\\\s*$/d' ${WORKSPACE}/fedmsg_fields.txt
-                    sed -i '/`/g' ${WORKSPACE}/fedmsg_fields.txt
-                    sed -i '/^fed/!d' ${WORKSPACE}/fedmsg_fields.txt
-                    sed -i 's/"//g' ${WORKSPACE}/fedmsg_fields.txt
-                    grep fed ${WORKSPACE}/fedmsg_fields.txt > ${WORKSPACE}/fedmsg_fields.txt.tmp
-                    mv ${WORKSPACE}/fedmsg_fields.txt.tmp ${WORKSPACE}/fedmsg_fields.txt
-                fi
-            '''
+                                        "import os\n" +
+                                        "\n" +
+                                        "ci_message = json.loads(os.environ['CI_MESSAGE'], encoding='utf-8')\n" +
+                                        "\n" +
+                                        "if 'commit' in ci_message:\n" +
+                                        "    ci_message = ci_message.get('commit')\n" +
+                                        "\n" +
+                                        "    with open(\"{0}/fedmsg_fields.groovy\".format(os.environ['WORKSPACE']), 'w') as f:\n" +
+                                        "        for k in ci_message:\n" +
+                                        "            if type(ci_message[k]) is str:\n" +
+                                        "                ci_message[k] = ci_message[k].replace('\"', \"'\")\n" +
+                                        "            if k == 'message':\n" +
+                                        "                ci_message[k] = ci_message[k].split('\\n')[0]\n" +
+                                        "            f.write('env.fed_{0}=\"{1}\"\\n'.format(k.replace('-', '_', ci_message[k]))"
 
                         // Load fedmsg fields as environment variables
-                        def fedmsg_fields = "${env.WORKSPACE}/fedmsg_fields.txt"
                         def fedmsg_fields_groovy = "${env.WORKSPACE}/fedmsg_fields.groovy"
-                        convertProps(fedmsg_fields, fedmsg_fields_groovy)
                         load(fedmsg_fields_groovy)
 
                         // Add Branch and Message Topic to properties and inject

--- a/Jenkinsfile-sl-pipeline
+++ b/Jenkinsfile-sl-pipeline
@@ -72,7 +72,8 @@ podTemplate(name: 'fedora-atomic-inline', label: 'fedora-atomic-inline', cloud: 
                             //emailext subject: "${env.JOB_NAME} - Build # ${env.BUILD_NUMBER} - STATUS = ${currentBuild.currentResult}", to: "ari@redhat.com", body: "This pipeline was a ${currentBuild.currentResult}"
 
                             step([$class: 'ArtifactArchiver', allowEmptyArchive: true,
-                                  artifacts: '**/logs/**,*.txt,*.groovy,**/job.*,**/*.groovy,**/inventory.*', excludes: '**/*.example',
+                                  artifacts: '**/logs/**,*.txt,*.groovy,**/job.*,**/*.groovy,**/inventory.*',
+                                  excludes: '**/job.props,**/job.props.groovy,**/*.example',
                                   fingerprint: true])
 
                             // Send message org.centos.prod.ci.pipeline.complete on fedmsg

--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -124,6 +124,8 @@ def setMessageFields(messageType){
                         "namespace=${fed_namespace}\n" +
                         "ref=fedora/${branch}/${basearch}/atomic-host\n" +
                         "repo=${fed_repo}\n" +
+                        "original_spec_nvr=${original_spec_nvr}\n" +
+                        "nvr=${nvr}\n" +
                         "rev=${fed_rev}\n" +
                         "test_guidance=''\n" +
                         "username=${RSYNC_USER}\n" +

--- a/vars/cicdPipeline.groovy
+++ b/vars/cicdPipeline.groovy
@@ -22,6 +22,9 @@ def call(body) {
         env.commit = env.commit ?: ''
         env.image2boot = env.image2boot ?: ''
         env.image_name = env.image_name ?: ''
+        env.package_url = env.package_url ?: ''
+        env.nvr = env.nvr ?: ''
+        env.original_spec_nvr = env.original_spec_nvr ?: ''
 
         // SCM
         dir('ci-pipeline') {

--- a/vars/rpmBuild.groovy
+++ b/vars/rpmBuild.groovy
@@ -1,3 +1,4 @@
+import org.centos.Messaging
 import org.centos.Utils
 import org.centos.pipeline.PipelineUtils
 
@@ -15,41 +16,28 @@ def call(body) {
 
     try {
         stage(current_stage) {
-            // Python script to parse the ${CI_MESSAGE}
+            // Python script to parse the ${CI_MESSAGE} and write out a fedmsg_fields.groovy file
             writeFile file: "${env.WORKSPACE}/parse_fedmsg.py",
-                    text: "#!/bin/env python\n" +
+                    text: "#! /usr/bin/env python\n" +
+                            "\n" +
                             "import json\n" +
-                            "import sys\n\n" +
-                            "reload(sys)\n" +
-                            "sys.setdefaultencoding('utf-8')\n" +
-                            "message = json.load(sys.stdin)\n" +
-                            "if 'commit' in message:\n" +
-                            "    msg = message['commit']\n\n" +
-                            "    for key in msg:\n" +
-                            "        safe_key = key.replace('-', '_')\n" +
-                            "        print \"fed_%s=%s\" % (safe_key, msg[key])\n"
-
-            // Parse the ${CI_MESSAGE}
-            sh '''
-                    #!/bin/bash
-                    set -xuo pipefail
-
-                    chmod +x ${WORKSPACE}/parse_fedmsg.py
-
-                    # Write fedmsg fields to a file to inject them
-                    if [ -n "${CI_MESSAGE}" ]; then
-                        echo ${CI_MESSAGE} | ${WORKSPACE}/parse_fedmsg.py > fedmsg_fields.txt
-                        sed -i '/^\\\\s*$/d' ${WORKSPACE}/fedmsg_fields.txt
-                        sed -i '/`/g' ${WORKSPACE}/fedmsg_fields.txt
-                        sed -i '/^fed/!d' ${WORKSPACE}/fedmsg_fields.txt
-                        grep fed ${WORKSPACE}/fedmsg_fields.txt > ${WORKSPACE}/fedmsg_fields.txt.tmp
-                        mv ${WORKSPACE}/fedmsg_fields.txt.tmp ${WORKSPACE}/fedmsg_fields.txt
-                    fi
-                '''
+                            "import os\n" +
+                            "\n" +
+                            "ci_message = json.loads(os.environ['CI_MESSAGE'], encoding='utf-8')\n" +
+                            "\n" +
+                            "if 'commit' in ci_message:\n" +
+                            "    ci_message = ci_message.get('commit')\n" +
+                            "\n" +
+                            "    with open(\"{0}/fedmsg_fields.groovy\".format(os.environ['WORKSPACE']), 'w') as f:\n" +
+                            "        for k in ci_message:\n" +
+                            "            if type(ci_message[k]) is str:\n" +
+                            "                ci_message[k] = ci_message[k].replace('\"', \"'\")\n" +
+                            "            if k == 'message':\n" +
+                            "                ci_message[k] = ci_message[k].split('\\n')[0]\n" +
+                            "            f.write('env.fed_{0}=\"{1}\"\\n'.format(k.replace('-', '_', ci_message[k]))"
 
             // Load fedmsg fields as environment variables
-            def fedmsg_fields = "${env.WORKSPACE}/fedmsg_fields.txt"
-            def fedmsg_fields_groovy = utils.convertProps(fedmsg_fields)
+            def fedmsg_fields_groovy = "${env.WORKSPACE}/fedmsg_fields.groovy"
             load(fedmsg_fields_groovy)
 
             // Add Branch and Message Topic to properties and inject


### PR DESCRIPTION
Updated the writeFile call with a python script that does the following:

* Parses the CI_MESSAGE env variable into JSON
* If the CI_MESSAGE contains a 'commit' key, it performs the following
  * For any key, if the key value is a string, replaces any double quote
    character within the value with a single quote.
  * Truncates the value of the message key at the first newline character
  * Writes the key/values in the following format to a file named
    fedmsg_fields.groovy in the workspace.
    * env.fed_{key}="{value}"

This removes the need to convert any files and this fedmsg_fields.groovy
file is injected with a call to load the file object.