### PR TITLE
FIXED python script to parse CI_MESSAGE

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -682,22 +682,22 @@ podTemplate(name: 'fedora-atomic-inline', label: 'fedora-atomic-inline', cloud: 
                     step([$class: 'ArtifactArchiver', allowEmptyArchive: true, artifacts: '**/logs/**,*.txt,*.groovy,**/job.*,**/*.groovy,**/inventory.*', excludes: '**/job.props,**/job.props.groovy,**/*.example', fingerprint: true])
 
                     // Send message org.centos.prod.ci.pipeline.complete on fedmsg
-//                    env.topic = "${env.MAIN_TOPIC}.ci.pipeline.complete"
-//                    messageProperties = "topic=${topic}\n" +
-//                            "build_url=${BUILD_URL}\n" +
-//                            "build_id=${BUILD_ID}\n" +
-//                            "branch=${branch}\n" +
-//                            "original_spec_nvr=${original_spec_nvr}\n" +
-//                            "nvr=${nvr}\n" +
-//                            "ref=fedora/${branch}/${basearch}/atomic-host\n" +
-//                            "rev=${fed_rev}\n" +
-//                            "repo=${fed_repo}\n" +
-//                            "namespace=${fed_namespace}\n" +
-//                            "username=fedora-atomic\n" +
-//                            "test_guidance=''\n" +
-//                            "status=${currentBuild.currentResult}"
-//                    messageContent = ''
-//                    sendMessage(messageProperties, messageContent)
+                    env.topic = "${env.MAIN_TOPIC}.ci.pipeline.complete"
+                    messageProperties = "topic=${topic}\n" +
+                            "build_url=${BUILD_URL}\n" +
+                            "build_id=${BUILD_ID}\n" +
+                            "branch=${branch}\n" +
+                            "original_spec_nvr=${original_spec_nvr}\n" +
+                            "nvr=${nvr}\n" +
+                            "ref=fedora/${branch}/${basearch}/atomic-host\n" +
+                            "rev=${fed_rev}\n" +
+                            "repo=${fed_repo}\n" +
+                            "namespace=${fed_namespace}\n" +
+                            "username=fedora-atomic\n" +
+                            "test_guidance=''\n" +
+                            "status=${currentBuild.currentResult}"
+                    messageContent = ''
+                    sendMessage(messageProperties, messageContent)
                 }
             }
         }

--- a/vars/rpmBuild.groovy
+++ b/vars/rpmBuild.groovy
@@ -28,13 +28,19 @@ def call(body) {
                             "if 'commit' in ci_message:\n" +
                             "    ci_message = ci_message.get('commit')\n" +
                             "\n" +
-                            "    with open(\"{0}/fedmsg_fields.groovy\".format(os.environ['WORKSPACE']), 'w') as f:\n" +
+                            "    with open(\"{0}/fedmsg_fields.groovy\".format(os.environ['WORKSPACE']), 'wb') as f:\n" +
                             "        for k in ci_message:\n" +
-                            "            if type(ci_message[k]) is str:\n" +
-                            "                ci_message[k] = ci_message[k].replace('\"', \"'\")\n" +
+                            "            if isinstance(ci_message[k], basestring):\n" +
+                            "                ci_message[k] = ci_message[k].replace('\"', \"'\").encode('utf-8')\n" +
                             "            if k == 'message':\n" +
                             "                ci_message[k] = ci_message[k].split('\\n')[0]\n" +
                             "            f.write('env.fed_{0}=\"{1}\"\\n'.format(k.replace('-', '_', ci_message[k]))"
+
+            // Chmod the python script to make it executable
+            sh 'chmod +x ${WORKSPACE}/parse_fedmsg.py'
+
+            // Execute the python script
+            sh '${WORKSPACE}/parse_fedmsg.py'
 
             // Load fedmsg fields as environment variables
             def fedmsg_fields_groovy = "${env.WORKSPACE}/fedmsg_fields.groovy"


### PR DESCRIPTION
Fixed the python script to parse the CI Message due to differences
between python3 (my dev env) and python2 (production env). Additionally,
adding a script, but failing to execute it in the pipeline does no good.
As such, I added sh steps to chmod+x the script and actually run it.

Finally, per @alivigni I uncommented the final sendMessage call in the
Jenkinsfile