### PR TITLE
Give the kernel job HTTP_BASE

### DIFF
--- a/tasks/kernel-ltp
+++ b/tasks/kernel-ltp
@@ -3,6 +3,9 @@
 set -x
 # Find the base dir
 base_dir="$(dirname $0)/.."
+if [ -z "${HTTP_BASE}" ]; then
+    HTTP_BASE=http://artifacts.ci.centos.org/fedora-atomic
+fi
 
 rm -rf logs
 mkdir -p logs


### PR DESCRIPTION
The kernel ltp job is more of a standalone thing for the kernel team to get some testing on the upstream kernel and check the results.  It isn't integrated into the pipeline (no idea when that would happen) and is still on ci.centos.org as a standalone job.  As such, it has no HTTP_BASE variable defined.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>