### PR TITLE
Check if there are atomic tagged tests first

### DIFF
--- a/config/Dockerfiles/package_tests/ansible/ansible_package_test.sh
+++ b/config/Dockerfiles/package_tests/ansible/ansible_package_test.sh
@@ -9,7 +9,7 @@
 curl -s --head https://upstreamfirst.fedorainfracloud.org/${package} | head -n 1 | grep "HTTP/1.[01] [23].." > /dev/null
 if [ $? -ne 0 ]; then
      echo "No upstream repo for this package! Exiting..."
-     exit 1
+     exit 0
 fi
 git clone https://upstreamfirst.fedorainfracloud.org/${package}
 if [[ $(grep "standard-test-beakerlib" ${package}/*.yml) == "" ]]; then

--- a/config/Dockerfiles/package_tests/ansible/ansible_package_test.sh
+++ b/config/Dockerfiles/package_tests/ansible/ansible_package_test.sh
@@ -17,6 +17,10 @@ if [[ $(grep "standard-test-beakerlib" ${package}/*.yml) == "" ]]; then
         exit 0
 fi
 if [ -f ${package}/tests.yml ]; then
+     if [[ $(ansible-playbook --list-tags ${package}/tests.yml) != *"atomic"* ]]; then
+         echo "No atomic tagged tests for this package!"
+         exit 0
+     fi
      sed 's/hosts: localhost/hosts: all/g' ${package}/tests.yml > ${package}/test_atomic.yml
      ansible-playbook -i /tmp/inventory --private-key=/tmp/ssh_key --tags=atomic --start-at-task='Define remote_artifacts if it is not already defined' ${package}/test_atomic.yml
      exit $?

--- a/config/Dockerfiles/package_tests/image/image_package_test.sh
+++ b/config/Dockerfiles/package_tests/image/image_package_test.sh
@@ -16,6 +16,10 @@ if [[ $(file ${TEST_SUBJECTS}) == *"No such file or directory"* ]]; then
 	export TEST_SUBJECTS=${PWD}/testimage.qcow2
 fi
 if [ -f ${package}/tests.yml ]; then
+     if [[ $(ansible-playbook --list-tags ${package}/tests.yml) != *"atomic"* ]]; then
+         echo "No atomic tagged tests for this package!"
+         exit 0
+     fi
      # Execute the tests
      ansible-playbook --tags atomic ${package}/tests.yml
      exit $?

--- a/config/Dockerfiles/package_tests/image/image_package_test.sh
+++ b/config/Dockerfiles/package_tests/image/image_package_test.sh
@@ -4,7 +4,7 @@
 curl -s --head https://upstreamfirst.fedorainfracloud.org/${package} | head -n 1 | grep "HTTP/1.[01] [23].." > /dev/null
 if [ $? -ne 0 ]; then
      echo "No upstream repo for this package! Exiting..."
-     exit 1
+     exit 0
 fi
 git clone https://upstreamfirst.fedorainfracloud.org/${package}
 if [[ $(grep "standard-test-beakerlib" ${package}/*.yml) == "" ]]; then


### PR DESCRIPTION
Currently the package level test containers just call the playbook if there are tests there that are beakerlib.  If there are beakerlib tests there, but they are not tagged for atomic, it will run and pass but have no results because nothing run, which is kind of confusing.  With this, it will echo out that there are no atomic tagged tests and do nothing.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>