### PR TITLE
Wait for koji tasks to finish

### DIFF
--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -60,7 +60,7 @@ rpmbuild -bs /root/rpmbuild/SOURCES/${fed_repo}.spec
 kinit -k -t /home/fedora.keytab $FEDORA_PRINCIPAL
 # Build the package into ./results_${fed_repo}/$VERSION/$RELEASE/ and concurrently do a koji build
 { time fedpkg --release ${fed_branch} mockbuild ; } 2> ${LOGDIR}/mockbuild.txt &
-{ time koji build --scratch $RSYNC_BRANCH /root/rpmbuild/SRPMS/${fed_repo}*.src.rpm ; } 2> ${LOGDIR}/kojibuildtime.txt &
+{ time koji build --wait --scratch $RSYNC_BRANCH /root/rpmbuild/SRPMS/${fed_repo}*.src.rpm ; } 2> ${LOGDIR}/kojibuildtime.txt &
 # Set status if either job fails to build the rpm
 MOCKBUILD_STATUS=SUCCESS
 MOCKBUILD_RC=0


### PR DESCRIPTION
We want accurate time measurements so let's not exit the command until it is finished.