### PR TITLE
Fix up rpmbuild Makefile find

### DIFF
--- a/config/Dockerfiles/rpmbuild/Dockerfile
+++ b/config/Dockerfiles/rpmbuild/Dockerfile
@@ -18,6 +18,7 @@ RUN for i in {1..5} ; do dnf -y install ansible \
         go \
         libsolv \
         mock \
+        perl \
         python-krbV \
         pyxdg \
         PyYAML \

--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -38,20 +38,22 @@ fedpkg --release ${fed_branch} prep
 VERSION=$(rpmspec --queryformat "%{VERSION}\n" -q ${fed_repo}.spec | head -n 1)
 # Some packages are packagename-version-release, some packagename-sha, some packagename[0-9]
 DIR_TO_GO=$(dirname $(find . -name Makefile | tail -n 1))
-pushd $DIR_TO_GO
-# Run configure if it exists, if not, no big deal
-./configure
-# Run tests if they are there
-make test >> ${LOGDIR}/make_test_output.txt
-MAKE_TEST_STATUS=$?
-popd
-if [ "$MAKE_TEST_STATUS" == 2 ]; then
-     echo "description='${fed_repo} - No tests'" >> ${LOGDIR}/package_props.txt
-elif [ "$MAKE_TEST_STATUS" == 0 ]; then
-     echo "description='${fed_repo} - make test passed'" >> ${LOGDIR}/package_props.txt
-else
-     echo "description='${fed_repo} - make test failed'" >> ${LOGDIR}/package_props.txt
-     exit $MAKE_TEST_STATUS
+if [ -n "$DIR_TO_GO" ] ; then
+    pushd $DIR_TO_GO
+    # Run configure if it exists, if not, no big deal
+    ./configure
+    # Run tests if they are there
+    make test >> ${LOGDIR}/make_test_output.txt
+    MAKE_TEST_STATUS=$?
+    popd
+    if [ "$MAKE_TEST_STATUS" == 2 ]; then
+         echo "description='${fed_repo} - No tests'" >> ${LOGDIR}/package_props.txt
+    elif [ "$MAKE_TEST_STATUS" == 0 ]; then
+         echo "description='${fed_repo} - make test passed'" >> ${LOGDIR}/package_props.txt
+    else
+         echo "description='${fed_repo} - make test failed'" >> ${LOGDIR}/package_props.txt
+         exit $MAKE_TEST_STATUS
+    fi
 fi
 # Prepare concurrent koji build
 cp -rp ../${fed_repo} /root/rpmbuild/SOURCES/

--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -37,7 +37,7 @@ sed -i "/^Release:/s/%{?dist}/.${commits}.${fed_rev:0:7}%{?dist}/" ${fed_repo}.s
 fedpkg --release ${fed_branch} prep
 VERSION=$(rpmspec --queryformat "%{VERSION}\n" -q ${fed_repo}.spec | head -n 1)
 # Some packages are packagename-version-release, some packagename-sha, some packagename[0-9]
-DIR_TO_GO=$(find . -maxdepth 1 -type d | cut -c 3- | grep ${fed_repo})
+DIR_TO_GO=$(dirname $(find . -name Makefile | tail -n 1))
 pushd $DIR_TO_GO
 # Run configure if it exists, if not, no big deal
 ./configure


### PR DESCRIPTION
The rpmbuild container searches for the Makefile's directory.  This was dependent on said directory containing the package name in its name.  That is not always the case.  This improves on that.  Also, some fedpkg preps (vim in particular) require perl, so install that.

Manually calling make test and ./configure may not be the best idea, so will have to be revisited.