### PR TITLE
exclude newer librepo from atomic-testing repo.

### DIFF
--- a/playbooks/roles/rdgo-system/tasks/main.yml
+++ b/playbooks/roles/rdgo-system/tasks/main.yml
@@ -20,6 +20,7 @@
       baseurl=http://cbs.centos.org/repos/atomic7-testing/x86_64/os/
       gpgcheck=0
       enabled=1
+      exclude=librepo
 
 # Ensure we see fresh data
 - command: yum clean expire-cache


### PR DESCRIPTION
newer librepo package built in atomic-testing does not
provide python-librepo which is required by bodhi-client
which is required for fedpkg now.