### PR TITLE
Turn on atomic-host-tests XUnit step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -626,7 +626,7 @@ podTemplate(name: 'fedora-atomic-inline', label: 'fedora-atomic-inline', cloud: 
 
                      step([$class: 'XUnitBuilder',
                           thresholds: [[$class: 'FailedThreshold', unstableThreshold: '1']],
-                          tools: [[$class: 'JUnitType', pattern: "**/**/*.xml"]]]
+                          tools: [[$class: 'JUnitType', pattern: "${env.ORIGIN_WORKSPACE}/logs/ansible_xunit.xml"]]]
                      )
 
                         // Send integration test complete message on fedmsg

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -624,10 +624,10 @@ podTemplate(name: 'fedora-atomic-inline', label: 'fedora-atomic-inline', cloud: 
                         echo "Duffy Deallocate ran for stage ${current_stage} with option ${env.DUFFY_OP}\r\n" +
                              "DUFFY_HOST=${env.DUFFY_HOST}"
 
-//                     step([$class: 'XUnitBuilder',
-//                          thresholds: [[$class: 'FailedThreshold', unstableThreshold: '1']],
-//                          tools: [[$class: 'JUnitType', pattern: "${env.ORIGIN_WORKSPACE}/logs/ansible_xunit.xml"]]]
-//                    )
+                     step([$class: 'XUnitBuilder',
+                          thresholds: [[$class: 'FailedThreshold', unstableThreshold: '1']],
+                          tools: [[$class: 'JUnitType', pattern: "**/**/*.xml"]]]
+                     )
 
                         // Send integration test complete message on fedmsg
                         env.topic = "${MAIN_TOPIC}.ci.pipeline.compose.test.integration.complete"


### PR DESCRIPTION
The step to consume the xunit results from the atomic-host-tests was previously commented out.  I assume this is because the atomic-host-tests stage was not configured properly, so none of the tests were running, so there were no xunit files to consume.  That has been fixed, so we can consume the results now.  The xunit file is ${env.ORIGIN_WORKSPACE}/logs/ansible_xunit.xml, which was what the path was in the commented code, but changing it to wildcards as has been done here allows more flexibility for more xunits to be added in the future and should still work as expected here.