### PR TITLE
Fix hardcoded f27=master in rpmbuild

### DIFF
--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -83,7 +83,7 @@ popd
 
 ABIGAIL_BRANCH=$(echo ${fed_branch} | sed 's/./&c/1')
 if [ "${fed_branch}" = "master" ]; then
-    ABIGAIL_BRANCH="fc27"
+    ABIGAIL_BRANCH="fc99"
 fi
 # Make repo with the newly created rpm
 rm -rf ${RPMDIR}/*


### PR DESCRIPTION
For libabigail, you cannot pass master or rawhide as your distro, so I had hardcoded master to be fc27.  However, for some reason, if you pass it in a release greater than the highest that exists, it defaults to latest, so at time of writing fc99 defaults to fc28, so this should work until we get to fc100, which is good enough for me.