### PR TITLE
Clear ~/.ssh/known_hosts every time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -771,6 +771,8 @@ def rsyncResults(stage) {
     
             cp ${FEDORA_KEYTAB} fedora.keytab
             chmod 0600 fedora.keytab
+            
+            rm -f ~/.ssh/known_hosts
 
             source ${ORIGIN_WORKSPACE}/task.env
             (echo -n "export RSYNC_PASSWORD=" && cat ~/duffy.key | cut -c '-13') > rsync-password.sh


### PR DESCRIPTION
16:33:04 Add correct host key in /home/jenkins/.ssh/known_hosts to get rid of this message.
16:33:04 Offending ECDSA key in /home/jenkins/.ssh/known_hosts:4

This should fix that error as far as I know.  Hopefully I put it in the right spot.