### PR TITLE
Revert removal of known_hosts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -771,8 +771,6 @@ def rsyncResults(stage) {
     
             cp ${FEDORA_KEYTAB} fedora.keytab
             chmod 0600 fedora.keytab
-            
-            rm -f ~/.ssh/known_hosts
 
             source ${ORIGIN_WORKSPACE}/task.env
             (echo -n "export RSYNC_PASSWORD=" && cat ~/duffy.key | cut -c '-13') > rsync-password.sh


### PR DESCRIPTION
The pipeline doesn't like connecting to duffy without a known_hosts file either.  We will need to do something with the UsersKnownHostsFile or something. Not sure yet.