### PR TITLE
really fix this method for one last time.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -806,15 +806,17 @@ def checkLastImage(stage) {
     echo "Currently in stage: ${stage} in checkLastImage"
 
     sh '''
-        meta=$(curl -f -I --silent ${HTTP_BASE}/${branch}/images/latest-atomic.qcow2)
-        curl_rc=$?
+        l_modified=$(curl -f -I --silent \
+                     ${HTTP_BASE}/${branch}/images/latest-atomic.qcow2 \
+                     | grep Last-Modified)
+        grep_rc=$?
 
-        prev=$( date --date="$( echo $meta| grep Last-Modified | sed s'/Last-Modified: //' )" +%s )
+        prev=$( date --date="$( echo $l_modified| sed s'/Last-Modified: //' )" +%s )
         cur=$( date +%s )
         
         elapsed=$((cur - prev))
-        if [ $curl_rc -ne 0 -o $elapsed -gt 86400 ]; then
-            echo "Time for a new image since time elapsed is ${elapsed} or no image exists curl return code:${curl_rc}"
+        if [ $grep_rc -ne 0 -o $elapsed -gt 86400 ]; then
+            echo "Time for a new image since time elapsed is ${elapsed} or no image exists return code:${grep_rc}"
             touch ${WORKSPACE}/NeedNewImage.txt
         else
             echo "No need for a new image not time yet since time elapsed is ${elapsed}"


### PR DESCRIPTION
jbieren pointed out you lose lines when you outout to a variable.
So need to do the grep inline before var assignment.  But we can't
add the sed or we will always pass unless we turn on pipefail.