### PR TITLE
Pull bodhi-client direct from koji build

### DIFF
--- a/config/Dockerfiles/ostree_compose/Dockerfile
+++ b/config/Dockerfiles/ostree_compose/Dockerfile
@@ -15,6 +15,7 @@ COPY walters-buildtools.repo /etc/yum.repos.d
 
 RUN yum clean expire-cache
 RUN yum -y localinstall https://kojipkgs.fedoraproject.org//packages/python-distro/1.0.1/2.el7/noarch/python2-distro-1.0.1-2.el7.noarch.rpm
+RUN yum -y localinstall https://kojipkgs.fedoraproject.org/packages/bodhi/2.10.1/2.el7/noarch/bodhi-client-2.10.1-2.el7.noarch.rpm https://kojipkgs.fedoraproject.org/packages/bodhi/2.10.1/2.el7/noarch/python2-bodhi-2.10.1-2.el7.noarch.rpm
 RUN yum -y install --disablerepo=epel-testing rsync mock libsolv glib2 ostree rpm-ostree rpm-ostree-toolbox fedpkg PyYAML rpmdistro-gitoverlay libgsystem genisoimage ansible
 
 RUN git clone https://github.com/CentOS-PaaS-SIG/ci-pipeline


### PR DESCRIPTION
newest bodhi-client has fixed dependencies to not
require python-dnf.