### PR TITLE
Cleanup README and fix jenkinsfile issue with atomic-host-tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -292,8 +292,7 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                         pipelineUtils.sendMessage(messageFields['properties'], messageFields['content'])
                     }
                     currentStage = "ci-pipeline-atomic-host-tests"
-                    stage(
-                            currentStage) {
+                    stage(currentStage) {
                         pipelineUtils.setStageEnvVars(currentStage)
 
                         // Set our message topic, properties, and content

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -307,6 +307,9 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                         // Stage resources - atomic host tests
                         pipelineUtils.setupStage(currentStage, 'fedora-atomic-key')
 
+                        // Rsync Data
+                        pipelineUtils.rsyncData(currentStage)
+
                         // Teardown resources
                         pipelineUtils.teardownResources(currentStage)
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ CI Pipeline messages sent via fedmsg for this stage are captured by the topics o
 
 If functional tests are successful in the previous stage of the pipeline then an OStree compose is generated.
 
-CI Pipeline messages sent via fedmsg for this stage are captured by the topics org.centos.prod.ci.pipeline.compose.[queued,running,complete].
+CI Pipeline messages sent via fedmsg for this stage are captured by the topics org.centos.prod.ci.pipeline.compose.[running,complete].
 
 ### Integration Tests on OStree
 
@@ -121,13 +121,13 @@ If integration tests of the images are successful an openshift cluster will be c
 
 An image will be initially generated at a certain interval when there has been successful integration test execution on an OStree compose. Success or failure will result with a fedmsg back to the Fedora reviewer/maintainer.  Also, this can trigger the Red Hat continuous delivery process to run more comprehensive testing if desired.
 
-CI Pipeline messages sent via fedmsg for this stage are captured by the topics org.centos.prod.ci.pipeline.image.[queued,running,complete].
+CI Pipeline messages sent via fedmsg for this stage are captured by the topics org.centos.prod.ci.pipeline.image.[running,complete].
 
 ### Image Smoke Test Validation
 
 The validation left is to make sure the image can boot and more smoke tests may follow if required.  Success or failure will result with a fedmsg back to the Fedora reviewer/maintainer.  Also, this can trigger the Red Hat continuous delivery process to run more comprehensive testing.
 
-CI Pipeline messages sent via fedmsg for this stage are captured by the topics org.centos.prod.ci.pipeline.image.test.smoke.[queued,running,complete].
+CI Pipeline messages sent via fedmsg for this stage are captured by the topics org.centos.prod.ci.pipeline.image.test.smoke.[running,complete].
 
 ## Message Bus
 

--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -465,7 +465,7 @@ def rsyncData(String stage){
     } else if (stage == 'ci-pipeline-ostree-image-boot-sanity') {
         text = text +
                 "export ANSIBLE_HOST_KEY_CHECKING=\"False\"\n"
-    } else if (stage == 'ci-pipeline-ostree-boot-sanity') {
+    } else if (stage in ['ci-pipeline-ostree-boot-sanity', 'ci-pipeline-atomic-host-tests']) {
         text = text +
                 "export fed_repo=\"${env.fed_repo}\"\n" +
                 "export image2boot=\"${env.image2boot}\"\n" +


### PR DESCRIPTION
I believe the syntax error in the Jenkinsfile is messing with the stage name and causing it to not run a task file on the duffy host again.
Signed-off-by: Johnny Bieren <jbieren@redhat.com>