### PR TITLE
Update README.md about queue messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ CI Pipeline messages sent via fedmsg for this stage are captured by the topics o
 
 If functional tests are successful in the previous stage of the pipeline then an OStree compose is generated.
 
-CI Pipeline messages sent via fedmsg for this stage are captured by the topics org.centos.prod.ci.pipeline.compose.[queued,running,complete].
+CI Pipeline messages sent via fedmsg for this stage are captured by the topics org.centos.prod.ci.pipeline.compose.[running,complete].
 
 ### Integration Tests on OStree
 
@@ -127,7 +127,7 @@ CI Pipeline messages sent via fedmsg for this stage are captured by the topics o
 
 The validation left is to make sure the image can boot and more smoke tests may follow if required.  Success or failure will result with a fedmsg back to the Fedora reviewer/maintainer.  Also, this can trigger the Red Hat continuous delivery process to run more comprehensive testing.
 
-CI Pipeline messages sent via fedmsg for this stage are captured by the topics org.centos.prod.ci.pipeline.image.test.smoke.[queued,running,complete].
+CI Pipeline messages sent via fedmsg for this stage are captured by the topics org.centos.prod.ci.pipeline.image.test.smoke.[running,complete].
 
 ## Message Bus
 


### PR DESCRIPTION
- We don't have queue messages for ostree amd smoke test
- We do for package, functional tests, and integration tests