### PR TITLE
Update rpmbuild container to f26

### DIFF
--- a/config/Dockerfiles/rpmbuild/Dockerfile
+++ b/config/Dockerfiles/rpmbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:24
+FROM fedora:26
 LABEL maintainer "https://github.com/CentOS-PaaS-SIG/ci-pipeline"
 LABEL description="This container is meant to \
 use fedpkg mock to create rpms.  It also rsyncs \
@@ -17,6 +17,7 @@ RUN for i in {1..5} ; do dnf -y install ansible \
         git \
         glib2 \
         go \
+        hostname \
         libsolv \
         mock \
         ncurses-devel \
@@ -39,6 +40,7 @@ RUN echo "config_opts['package_manager'] = 'dnf'" >> /etc/mock/site-defaults.cfg
 RUN echo "config_opts['plugin_conf']['lvm_root_opts']['size'] = '16G'" >> /etc/mock/site-defaults.cfg
 RUN echo "config_opts['plugin_conf']['lvm_root_opts']['poolmetadatasize'] = '30G'" >> /etc/mock/site-defaults.cfg
 RUN echo "config_opts['basedir'] = '/home/rpmbuild/'" >> /etc/mock/site-defaults.cfg
+RUN echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 
 # Change the anongiturl for fedpkg
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1495378
@@ -53,4 +55,3 @@ COPY rpmbuild-test.sh /tmp/rpmbuild-test.sh
 ENTRYPOINT ["bash", "/tmp/rpmbuild-test.sh"]
 # Run the container as follows
 # docker run --privileged -v /log/parent/dir:/home -e fed_repo=${packagename} -e fed_branch=${fed_branch} -e fed_rev=${fed_rev} -e RSYNC_PASSWORD=${rsync_password} HTTP_BASE="${HTTP_BASE}" -e RSYNC_HOST="${RSYNC_USER}@${RSYNC_SERVER}" -e RSYNC_DIR="${RSYNC_DIR}" container_tag
-

--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -73,7 +73,7 @@ ls
 kinit -k -t /home/fedora.keytab $FEDORA_PRINCIPAL
 # Build the package into ./results_${fed_repo}/$VERSION/$RELEASE/ and concurrently do a koji build
 { time fedpkg --release ${fed_branch} mockbuild ; } 2> ${LOGDIR}/mockbuild.txt &
-{ time koji build --wait --arch-override=x86_64 --scratch $RSYNC_BRANCH /root/rpmbuild/SRPMS/${fed_repo}*.src.rpm ; } 2> ${LOGDIR}/kojibuildtime.txt &
+{ time python2 /usr/bin/koji build --wait --arch-override=x86_64 --scratch $RSYNC_BRANCH /root/rpmbuild/SRPMS/${fed_repo}*.src.rpm ; } 2> ${LOGDIR}/kojibuildtime.txt &
 # Set status if either job fails to build the rpm
 MOCKBUILD_RC=0
 for job in `jobs -p`; do


### PR DESCRIPTION
We were sticking to F24 for the rpmbuild container because mock wasn't working on F25. It wasn't working on F26, either.  It wasn't working on those releases because it was using nspawn.  This should fix it (worked locally for me).
Signed-off-by: Johnny Bieren <jbieren@redhat.com>