### PR TITLE
Add rpm build logs

### DIFF
--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -101,6 +101,8 @@ cp ${CURRENTDIR}/${fed_repo}/results_${fed_repo}/${VERSION}/*/*.rpm ${RPMDIR}/
 # Run rpmlint
 rpmlint ${RPMDIR}/ > ${LOGDIR}/rpmlint_out.txt
 pushd ${RPMDIR} && createrepo .
+mkdir logs
+cp ${CURRENTDIR}/${fed_repo}/results_${fed_repo}/${VERSION}/*/*.log logs/
 popd
 # Run fedabipkgdiff against the newly created rpm
 rm -rf libabigail

--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -103,6 +103,7 @@ rpmlint ${RPMDIR}/ > ${LOGDIR}/rpmlint_out.txt
 pushd ${RPMDIR} && createrepo .
 mkdir logs
 cp ${CURRENTDIR}/${fed_repo}/results_${fed_repo}/${VERSION}/*/*.log logs/
+cp ${CURRENTDIR}/${fed_repo}/results_${fed_repo}/${VERSION}/*/*.log ${LOGDIR}/
 popd
 # Run fedabipkgdiff against the newly created rpm
 rm -rf libabigail


### PR DESCRIPTION
I believe adding build logs for the rpm stage should be this easy. I will be curious of the stage pipeline results on this though, as I am not 100% sure if the ostree stages will complain about something besides .rpm files being in the artifact directories.
Signed-off-by: Johnny Bieren <jbieren@redhat.com>