### PR TITLE
Create an image every time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,6 +222,24 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                         pipelineUtils.checkLastImage(currentStage)
                     }
 
+                    currentStage = "ci-pipeline-ostree-boot-sanity"
+                    stage(currentStage) {
+                        pipelineUtils.setStageEnvVars(currentStage)
+
+                        // Provision resources
+                        pipelineUtils.provisionResources(currentStage)
+
+                        // Stage resources - ostree boot sanity
+                        pipelineUtils.setupStage(currentStage, 'fedora-atomic-key')
+
+                        // Rsync Data
+                        pipelineUtils.rsyncData(currentStage)
+
+                        // Teardown resources
+                        pipelineUtils.teardownResources(currentStage)
+
+                    }
+
                     currentStage = "ci-pipeline-ostree-image-compose"
                     stage(currentStage) {
                         // Set stage specific vars
@@ -256,9 +274,9 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                             ostree_props = "${env.ORIGIN_WORKSPACE}/logs/ostree.props"
                             ostree_props_groovy = "${env.ORIGIN_WORKSPACE}/ostree.props.groovy"
                             pipelineUtils.convertProps(ostree_props, ostree_props_groovy)
+                            load(ostree_props_groovy)
                         }
                         sh "mv -f ${env.ORIGIN_WORKSPACE}/logs/latest-atomic.qcow2 ${env.WORKSPACE}/"
-                        load(ostree_props_groovy)
 
                         // Teardown resources
                         pipelineUtils.teardownResources(currentStage)
@@ -281,7 +299,7 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                             pipelineUtils.setStageEnvVars(currentStage)
 
                             // Set our message topic, properties, and content
-                            messageFields = pipelineUtils.setMessageFields("smoke.running")
+                            messageFields = pipelineUtils.setMessageFields("image.test.smoke.running")
 
                             // Send message org.centos.prod.ci.pipeline.smoke.running on fedmsg
                             pipelineUtils.sendMessage(messageFields['properties'], messageFields['content'])
@@ -299,7 +317,7 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                             pipelineUtils.teardownResources(currentStage)
 
                             // Set our message topic, properties, and content
-                            messageFields = pipelineUtils.setMessageFields("smoke.complete")
+                            messageFields = pipelineUtils.setMessageFields("image.test.smoke.complete")
 
                             // Send message org.centos.prod.ci.pipeline.smoke.complete on fedmsg
                             pipelineUtils.sendMessage(messageFields['properties'], messageFields['content'])
@@ -307,37 +325,20 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                         } else {
                             echo "Not Running Image Boot Sanity on Image"
                         }
-                    }
-
-                    currentStage = "ci-pipeline-ostree-boot-sanity"
-                    stage(currentStage) {
-                        pipelineUtils.setStageEnvVars(currentStage)
-
-                        // Provision resources
-                        pipelineUtils.provisionResources(currentStage)
-
-                        // Stage resources - ostree boot sanity
-                        pipelineUtils.setupStage(currentStage, 'fedora-atomic-key')
-
-                        // Rsync Data
-                        pipelineUtils.rsyncData(currentStage)
-
-                        // Teardown resources
-                        pipelineUtils.teardownResources(currentStage)
 
                         // Set our message topic, properties, and content
-                        messageFields = pipelineUtils.setMessageFields("integration.queued")
+                        messageFields = pipelineUtils.setMessageFields("compose.test.integration.queued")
 
                         // Send message org.centos.prod.ci.pipeline.integration.queued on fedmsg
                         pipelineUtils.sendMessage(messageFields['properties'], messageFields['content'])
                     }
+
                     currentStage = "ci-pipeline-atomic-host-tests"
-                    stage(
-                            currentStage) {
+                    stage(currentStage) {
                         pipelineUtils.setStageEnvVars(currentStage)
 
                         // Set our message topic, properties, and content
-                        messageFields = pipelineUtils.setMessageFields("integration.running")
+                        messageFields = pipelineUtils.setMessageFields("compose.test.integration.running")
 
                         // Send message org.centos.prod.ci.pipeline.integration.running on fedmsg
                         pipelineUtils.sendMessage(messageFields['properties'], messageFields['content'])
@@ -352,7 +353,7 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                         pipelineUtils.teardownResources(currentStage)
 
                         // Set our message topic, properties, and content
-                        messageFields = pipelineUtils.setMessageFields("integration.complete")
+                        messageFields = pipelineUtils.setMessageFields("compose.test.integration.complete")
 
                         // Send message org.centos.prod.ci.pipeline.integration.complete on fedmsg
                         pipelineUtils.sendMessage(messageFields['properties'], messageFields['content'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -252,7 +252,7 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
 
                         ostree_props = "${env.ORIGIN_WORKSPACE}/logs/ostree.props"
                         ostree_props_groovy = "${env.ORIGIN_WORKSPACE}/ostree.props.groovy"
-                        sh "mv -f ${env.ORIGIN_WORKSPACE}/latest-atomic.qcow2 ${env.WORKSPACE}/"
+                        sh "mv -f ${env.ORIGIN_WORKSPACE}/logs/latest-atomic.qcow2 ${env.WORKSPACE}/"
                         pipelineUtils.convertProps(ostree_props, ostree_props_groovy)
                         load(ostree_props_groovy)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,10 +250,14 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                         // Rsync Data
                         pipelineUtils.rsyncData(currentStage)
 
-                        ostree_props = "${env.ORIGIN_WORKSPACE}/logs/ostree.props"
-                        ostree_props_groovy = "${env.ORIGIN_WORKSPACE}/ostree.props.groovy"
+                        if (fileExists("${env.WORKSPACE}/NeedNewImage.txt") || ("${env.GENERATE_IMAGE}" == "true")) {
+                            // These variables will mess with boot sanity jobs
+                            // later if they are injected from a non pushed img
+                            ostree_props = "${env.ORIGIN_WORKSPACE}/logs/ostree.props"
+                            ostree_props_groovy = "${env.ORIGIN_WORKSPACE}/ostree.props.groovy"
+                            pipelineUtils.convertProps(ostree_props, ostree_props_groovy)
+                        }
                         sh "mv -f ${env.ORIGIN_WORKSPACE}/logs/latest-atomic.qcow2 ${env.WORKSPACE}/"
-                        pipelineUtils.convertProps(ostree_props, ostree_props_groovy)
                         load(ostree_props_groovy)
 
                         // Teardown resources

--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -220,8 +220,8 @@ def setMessageFields(String messageType){
         messageProperties = messageProperties +
                 "compose_url=${env.HTTP_BASE}/${env.branch}/ostree\n"
                 "compose_rev=''\n"
-    } else if ((messageType == 'compose.complete') || (messageType == 'test.integration.queued') ||
-            (messageType == 'test.integration.running') || (messageType == 'test.integration.complete')) {
+    } else if ((messageType == 'compose.complete') || (messageType == 'compose.test.integration.queued') ||
+            (messageType == 'compose.test.integration.running') || (messageType == 'compose.test.integration.complete')) {
         messageProperties = messageProperties +
             "compose_url=${env.HTTP_BASE}/${env.branch}/ostree\n"
             "compose_rev=${env.commit}\n"
@@ -232,8 +232,8 @@ def setMessageFields(String messageType){
                 "image_url=''\n" +
                 "image_name=''\n" +
                 "type=qcow2\n"
-    } else if ((messageType == 'image.complete') || (messageType == 'test.smoke.running') ||
-            (messageType == 'test.smoke.compelete')) {
+    } else if ((messageType == 'image.complete') || (messageType == 'image.test.smoke.running') ||
+            (messageType == 'image.test.smoke.compelete')) {
         messageProperties = messageProperties +
                 "compose_url=${env.HTTP_BASE}/${env.branch}/ostree\n"
                 "compose_rev=${env.commit}\n" +

--- a/tasks/ostree-image-compose
+++ b/tasks/ostree-image-compose
@@ -29,8 +29,8 @@ sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/output:/home/outp
 sudo docker run --privileged -e 'container=docker' -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v ${HOMEDIR}/output:/home/output -e branch="${branch}" -e HTTP_BASE="${HTTP_BASE}" ostree_image_compose-container
 
 # Logs need to be in a specific place to be picked up.
+sudo cp -f ${HOMEDIR}/output/images/latest-atomic.qcow2 ${HOMEDIR}/output/logs/latest-atomic.qcow2
 sudo mv ${HOMEDIR}/output/logs ${HOMEDIR}
-sudo cp ${HOMEDIR}/output/images/latest-atomic.qcow2 ${HOMEDIR}/
 
 # Only rsync image to artifacts.ci.centos.org if PUSH_IMAGE = true
 if [ ${PUSH_IMAGE} = "true" ]; then

--- a/tasks/ostree-image-compose
+++ b/tasks/ostree-image-compose
@@ -30,5 +30,9 @@ sudo docker run --privileged -e 'container=docker' -v /sys/fs/cgroup:/sys/fs/cgr
 
 # Logs need to be in a specific place to be picked up.
 sudo mv ${HOMEDIR}/output/logs ${HOMEDIR}
+sudo cp ${HOMEDIR}/output/images/latest-atomic.qcow2 ${HOMEDIR}/
 
-sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/output:/home/output -e rsync_paths="images" -e rsync_to="${RSYNC_USER}@${RSYNC_SERVER}::${RSYNC_DIR}/${branch}/" -e rsync_from="/home/output/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" rsync-container
+# Only rsync image to artifacts.ci.centos.org if PUSH_IMAGE = true
+if [ ${PUSH_IMAGE} = "true" ]; then
+     sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/output:/home/output -e rsync_paths="images" -e rsync_to="${RSYNC_USER}@${RSYNC_SERVER}::${RSYNC_DIR}/${branch}/" -e rsync_from="/home/output/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" rsync-container
+fi


### PR DESCRIPTION
This forces image-compose to run every time, but it will only rsync if the conditions from before are met.  It then copies the qcow2 into the workspace.  This sets us up to allow package testing with that as the subject if it works.
Signed-off-by: Johnny Bieren <jbieren@redhat.com>