### PR TITLE
Image compose needs to happen before ostree boot sanity

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,24 +222,6 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                         pipelineUtils.checkLastImage(currentStage)
                     }
 
-                    currentStage = "ci-pipeline-ostree-boot-sanity"
-                    stage(currentStage) {
-                        pipelineUtils.setStageEnvVars(currentStage)
-
-                        // Provision resources
-                        pipelineUtils.provisionResources(currentStage)
-
-                        // Stage resources - ostree boot sanity
-                        pipelineUtils.setupStage(currentStage, 'fedora-atomic-key')
-
-                        // Rsync Data
-                        pipelineUtils.rsyncData(currentStage)
-
-                        // Teardown resources
-                        pipelineUtils.teardownResources(currentStage)
-
-                    }
-
                     currentStage = "ci-pipeline-ostree-image-compose"
                     stage(currentStage) {
                         // Set stage specific vars
@@ -331,6 +313,30 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
 
                         // Send message org.centos.prod.ci.pipeline.integration.queued on fedmsg
                         pipelineUtils.sendMessage(messageFields['properties'], messageFields['content'])
+                    }
+
+                    currentStage = "ci-pipeline-ostree-boot-sanity"
+                    stage(currentStage) {
+                        pipelineUtils.setStageEnvVars(currentStage)
+
+                        // Provision resources
+                        pipelineUtils.provisionResources(currentStage)
+
+                        // Stage resources - ostree boot sanity
+                        pipelineUtils.setupStage(currentStage, 'fedora-atomic-key')
+
+                        // Rsync Data
+                        pipelineUtils.rsyncData(currentStage)
+
+                        // Teardown resources
+                        pipelineUtils.teardownResources(currentStage)
+
+                        // Set our message topic, properties, and content
+                        messageFields = pipelineUtils.setMessageFields("compose.test.integration.queued")
+
+                        // Send message org.centos.prod.ci.pipeline.integration.queued on fedmsg
+                        pipelineUtils.sendMessage(messageFields['properties'], messageFields['content'])
+
                     }
 
                     currentStage = "ci-pipeline-atomic-host-tests"

--- a/tasks/ostree-image-compose
+++ b/tasks/ostree-image-compose
@@ -33,6 +33,6 @@ sudo cp -f ${HOMEDIR}/output/images/latest-atomic.qcow2 ${HOMEDIR}/output/logs/l
 sudo mv ${HOMEDIR}/output/logs ${HOMEDIR}
 
 # Only rsync image to artifacts.ci.centos.org if PUSH_IMAGE = true
-if [ ${PUSH_IMAGE} = "true" ]; then
+if [ "${PUSH_IMAGE}" = "true" ]; then
      sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/output:/home/output -e rsync_paths="images" -e rsync_to="${RSYNC_USER}@${RSYNC_SERVER}::${RSYNC_DIR}/${branch}/" -e rsync_from="/home/output/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" rsync-container
 fi


### PR DESCRIPTION
I previously put ostree boot sanity before image compose, because I did not see why you would build an image for an ostree that doesn't even boot, but ostree boot requires an image to exist to work.
Signed-off-by: Johnny Bieren <jbieren@redhat.com>