### PR TITLE
ostree-image-compose must come first

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,24 +222,6 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                         pipelineUtils.checkLastImage(currentStage)
                     }
 
-                    currentStage = "ci-pipeline-ostree-boot-sanity"
-                    stage(currentStage) {
-                        pipelineUtils.setStageEnvVars(currentStage)
-
-                        // Provision resources
-                        pipelineUtils.provisionResources(currentStage)
-
-                        // Stage resources - ostree boot sanity
-                        pipelineUtils.setupStage(currentStage, 'fedora-atomic-key')
-
-                        // Rsync Data
-                        pipelineUtils.rsyncData(currentStage)
-
-                        // Teardown resources
-                        pipelineUtils.teardownResources(currentStage)
-
-                    }
-
                     currentStage = "ci-pipeline-ostree-image-compose"
                     stage(currentStage) {
                         // Set stage specific vars
@@ -276,7 +258,7 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                             pipelineUtils.convertProps(ostree_props, ostree_props_groovy)
                             load(ostree_props_groovy)
                         }
-                        sh "mv -f ${env.ORIGIN_WORKSPACE}/logs/latest-atomic.qcow2 ${env.WORKSPACE}/"
+                        sh "mv -f ${env.ORIGIN_WORKSPACE}/logs/untested-atomic.qcow2 ${env.WORKSPACE}/"
 
                         // Teardown resources
                         pipelineUtils.teardownResources(currentStage)
@@ -326,11 +308,30 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                             echo "Not Running Image Boot Sanity on Image"
                         }
 
+                    }
+
+                    currentStage = "ci-pipeline-ostree-boot-sanity"
+                    stage(currentStage) {
+                        pipelineUtils.setStageEnvVars(currentStage)
+
+                        // Provision resources
+                        pipelineUtils.provisionResources(currentStage)
+
+                        // Stage resources - ostree boot sanity
+                        pipelineUtils.setupStage(currentStage, 'fedora-atomic-key')
+
+                        // Rsync Data
+                        pipelineUtils.rsyncData(currentStage)
+
+                        // Teardown resources
+                        pipelineUtils.teardownResources(currentStage)
+
                         // Set our message topic, properties, and content
                         messageFields = pipelineUtils.setMessageFields("compose.test.integration.queued")
 
                         // Send message org.centos.prod.ci.pipeline.integration.queued on fedmsg
                         pipelineUtils.sendMessage(messageFields['properties'], messageFields['content'])
+
                     }
 
                     currentStage = "ci-pipeline-atomic-host-tests"

--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -454,6 +454,7 @@ def rsyncData(String stage){
                          'ci-pipeline-ostree-image-boot-sanity', 'ci-pipeline-ostree-boot-sanity']) {
         text = text +
                 "export HTTP_BASE=\"${env.HTTP_BASE}\"\n" +
+                "export PUSH_IMAGE=\"${env.PUSH_IMAGE}\"\n" +
                 "export branch=\"${env.branch}\"\n"
     }
     if (stage == 'ci-pipeline-rpmbuild') {

--- a/tasks/ostree-image-compose
+++ b/tasks/ostree-image-compose
@@ -29,10 +29,10 @@ sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/output:/home/outp
 sudo docker run --privileged -e 'container=docker' -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v ${HOMEDIR}/output:/home/output -e branch="${branch}" -e HTTP_BASE="${HTTP_BASE}" ostree_image_compose-container
 
 # Logs need to be in a specific place to be picked up.
-sudo cp -f ${HOMEDIR}/output/images/latest-atomic.qcow2 ${HOMEDIR}/output/logs/latest-atomic.qcow2
+sudo cp -f $(ls -tr /${HOMEDIR}/output/images/fedora-atomic-*.qcow2 | tail -n 1) ${HOMEDIR}/output/logs/untested-atomic.qcow2
 sudo mv ${HOMEDIR}/output/logs ${HOMEDIR}
 
 # Only rsync image to artifacts.ci.centos.org if PUSH_IMAGE = true
-if [ ${PUSH_IMAGE} = "true" ]; then
+if [ "${PUSH_IMAGE}" = "true" ]; then
      sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/output:/home/output -e rsync_paths="images" -e rsync_to="${RSYNC_USER}@${RSYNC_SERVER}::${RSYNC_DIR}/${branch}/" -e rsync_from="/home/output/" -e RSYNC_PASSWORD="$RSYNC_PASSWORD" rsync-container
 fi


### PR DESCRIPTION
I previously put ostree boot sanity before image compose, because I did not see why you would build an image for an ostree that doesn't even boot, but ostree boot requires an image to exist to work.
Signed-off-by: Johnny Bieren <jbieren@redhat.com>