### PR TITLE
Archive logs on mockbuild failure

### DIFF
--- a/config/Dockerfiles/ostree_image_compose/ostree-image-compose.sh
+++ b/config/Dockerfiles/ostree_image_compose/ostree-image-compose.sh
@@ -78,7 +78,8 @@ sed -i "s|^ostreesetup.*|ostreesetup --nogpg --osname=fedora-atomic --remote=fed
 sed -i "s|\(%end.*$\)|ostree remote delete fedora-atomic\nostree remote add --set=gpg-verify=false fedora-atomic ${HTTP_BASE}/${branch}/ostree\n\1|" /home/output/logs/fedora-atomic.ks
 
 # Remove ostree refs create form upstream kickstart
-sed -i "s|^ostree refs.*--create.*||" /home/output/logs/fedora-atomic.ks
+sed -i "s|^ostree refs.*||" /home/output/logs/fedora-atomic.ks
+sed -i "s|^ostree admin set-origin.*||" /home/output/logs/fedora-atomic.ks
 
 # Create a tdl file for imagefactory
 #       <install type='url'>

--- a/config/Dockerfiles/ostree_image_compose/ostree-image-compose.sh
+++ b/config/Dockerfiles/ostree_image_compose/ostree-image-compose.sh
@@ -77,6 +77,9 @@ sed -i "s|^ostreesetup.*|ostreesetup --nogpg --osname=fedora-atomic --remote=fed
 # point to upstream
 sed -i "s|\(%end.*$\)|ostree remote delete fedora-atomic\nostree remote add --set=gpg-verify=false fedora-atomic ${HTTP_BASE}/${branch}/ostree\n\1|" /home/output/logs/fedora-atomic.ks
 
+# Remove ostree refs create form upstream kickstart
+sed -i "s|^ostree refs.*--create.*||" /home/output/logs/fedora-atomic.ks
+
 # Create a tdl file for imagefactory
 #       <install type='url'>
 #           <url>http://download.fedoraproject.org/pub/fedora/linux/releases/25/Everything/x86_64/os/</url>


### PR DESCRIPTION
Currently, if the mock build just fails, the build logs are never moved to the proper spot to be archived and stored as jenkins artifacts (still no rsync would happen in this scenario)

Signed-off-by: Johnny Bieren <jbieren@redhat.com>