### PR TITLE
Containerize atomic host tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -234,7 +234,7 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                         // Set our message topic, properties, and content
                         messageFields = pipelineUtils.setMessageFields("compose.complete")
 
-                        // Send message org.centos.prod.ci.pipeline.package.complete on fedmsg
+                        // Send message org.centos.prod.ci.pipeline.compose.complete on fedmsg
                         pipelineUtils.sendMessageWithAudit(messageFields['properties'], messageFields['content'], msgAuditFile)
 
                         pipelineUtils.checkLastImage(currentStage)
@@ -301,7 +301,7 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                             // Set our message topic, properties, and content
                             messageFields = pipelineUtils.setMessageFields("image.test.smoke.running")
 
-                            // Send message org.centos.prod.ci.pipeline.smoke.running on fedmsg
+                            // Send message org.centos.prod.ci.pipeline.image.test.smoke.running on fedmsg
                             pipelineUtils.sendMessageWithAudit(messageFields['properties'], messageFields['content'], msgAuditFile)
 
                             // Provision resources
@@ -319,7 +319,7 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                             // Set our message topic, properties, and content
                             messageFields = pipelineUtils.setMessageFields("image.test.smoke.complete")
 
-                            // Send message org.centos.prod.ci.pipeline.smoke.complete on fedmsg
+                            // Send message org.centos.prod.ci.pipeline.image.test.smoke.complete on fedmsg
                             pipelineUtils.sendMessageWithAudit(messageFields['properties'], messageFields['content'], msgAuditFile)
 
                         } else {
@@ -363,6 +363,7 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                         // Send message org.centos.prod.ci.pipeline.package.test.functional.running on fedmsg
                         pipelineUtils.sendMessage(messageFields['properties'], messageFields['content'])
 
+                        // Run functional tests
                         pipelineUtils.executeInContainer(currentStage, "package-test", "/tmp/package-test.sh")
 
                         // Set our message topic, properties, and content
@@ -374,32 +375,29 @@ podTemplate(name: 'fedora-atomic-' + env.ghprbActualCommit,
                         // Set our message topic, properties, and content
                         messageFields = pipelineUtils.setMessageFields("compose.test.integration.queued")
 
-                        // Send message org.centos.prod.ci.pipeline.integration.queued on fedmsg
+                        // Send message org.centos.prod.ci.pipeline.compose.test.integration.queued on fedmsg
                         pipelineUtils.sendMessageWithAudit(messageFields['properties'], messageFields['content'], msgAuditFile)
                     }
 
                     currentStage = "ci-pipeline-atomic-host-tests"
                     stage(currentStage) {
+                        // Set stage specific vars
                         pipelineUtils.setStageEnvVars(currentStage)
+                        env.RSYNC_PASSWORD = "${env.REAL_RSYNC_PASSWORD}"
 
                         // Set our message topic, properties, and content
                         messageFields = pipelineUtils.setMessageFields("compose.test.integration.running")
 
-                        // Send message org.centos.prod.ci.pipeline.integration.running on fedmsg
+                        // Send message org.centos.prod.ci.pipeline.compose.test.integration.running on fedmsg
                         pipelineUtils.sendMessageWithAudit(messageFields['properties'], messageFields['content'], msgAuditFile)
 
-                        // Provision resources
-                        pipelineUtils.provisionResources(currentStage)
-
-                        // Stage resources - atomic host tests
-                        pipelineUtils.setupStage(currentStage, 'fedora-atomic-key')
-
-                        // Teardown resources
-                        pipelineUtils.teardownResources(currentStage)
+                        // Run integration tests
+                        pipelineUtils.executeInContainer(currentStage, "package-test", "/tmp/integration-test.sh")
 
                         // Set our message topic, properties, and content
                         messageFields = pipelineUtils.setMessageFields("compose.test.integration.complete")
 
+                        // Send message org.centos.prod.ci.pipeline.compose.test.integration.complete on fedmsg
                         pipelineUtils.sendMessageWithAudit(messageFields['properties'], messageFields['content'], msgAuditFile)
                     }
 

--- a/config/Dockerfiles/package-test/Dockerfile
+++ b/config/Dockerfiles/package-test/Dockerfile
@@ -4,7 +4,9 @@ LABEL description="This container is meant to \
 use dist-git tests to test packages, \
 provided a package name and an image to test against. \
 If there are no dist-git tests, it checks \
-upstreamfirst.fedorainfracloud.org."
+upstreamfirst.fedorainfracloud.org. It also can run \
+integration tests from the projectatomic repo by calling \
+the integration-test.sh script."
 
 # Copy restraint repo into container
 RUN curl -o /etc/yum.repos.d/bpeck-restraint-fedora-26.repo https://copr.fedorainfracloud.org/coprs/bpeck/restraint/repo/fedora-26/bpeck-restraint-fedora-26.repo
@@ -17,6 +19,7 @@ RUN for i in {1..5} ; do dnf -y install ansible \
         findutils \
         git \
         restraint-rhts \
+        rsync \
         sudo \
         wget \
         && dnf clean all \
@@ -28,6 +31,7 @@ Run dnf -y install standard-test-roles \
 
 # Copy the build script to the container
 COPY package-test.sh /tmp/package-test.sh
+COPY integration-test.sh /tmp/integration-test.sh
 
 # Run the build script
 ENTRYPOINT ["bash", "/tmp/package-test.sh"]

--- a/config/Dockerfiles/package-test/integration-test.sh
+++ b/config/Dockerfiles/package-test/integration-test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -eu
+
+CURRENTDIR=$(pwd)
+if [ ${CURRENTDIR} == "/" ] ; then
+    cd /home
+    CURRENTDIR=/home
+fi
+# admin-unlock, pkg-layering and system-containers require reboots so cant be run with standard-test-roles
+export ENABLED_TESTS="docker-build-httpd docker-swarm docker"
+export TEST_SUBJECTS=${CURRENTDIR}/untested-atomic.qcow2
+export TEST_ARTIFACTS=${CURRENTDIR}/logs
+# The test artifacts must be an empty directory
+rm -rf ${TEST_ARTIFACTS}
+mkdir -p ${TEST_ARTIFACTS}
+
+# Make sure we have or have downloaded the test subject
+if [ -z "${TEST_SUBJECTS:-}" ]; then
+	echo "No subject defined"
+	exit 2
+elif ! file ${TEST_SUBJECTS:-}; then
+	wget -q -O testimage.qcow2 ${TEST_SUBJECTS}
+	export TEST_SUBJECTS=${PWD}/testimage.qcow2
+fi
+
+# The inventory must be from the test if present (file or directory) or defaults
+ANSIBLE_INVENTORY=$(test -e inventory && echo inventory || echo /usr/share/ansible/inventory)
+export ANSIBLE_INVENTORY
+
+# This will introduce a problem with concurrency as it has no locks
+function clean_up {
+if [[ -z "${RSYNC_USER}" || -z "${RSYNC_SERVER}" || -z "${RSYNC_DIR}" || -z "${RSYNC_PASSWORD}" ]]; then echo "Told to rsync but missing rsync env var(s)" ; exit 1 ; fi
+     RSYNC_BRANCH=${branch}
+     if [ "${branch}" = "master" ]; then
+         RSYNC_BRANCH=rawhide
+     fi
+     RSYNC_LOCATION="${RSYNC_USER}@${RSYNC_SERVER}::${RSYNC_DIR}/${RSYNC_BRANCH}"
+     rm -rf tests/integration
+     mkdir -p tests/integration
+     cp ${TEST_ARTIFACTS}/*.log tests/integration/
+     rsync --stats -arv tests ${RSYNC_LOCATION}/repo/${package}_repo/logs
+}
+trap clean_up EXIT SIGHUP SIGINT SIGTERM
+
+# Get integration tests repo
+git clone https://github.com/projectatomic/atomic-host-tests
+pushd atomic-host-tests
+
+# Change test config
+sed -i s/true/false/ tests/docker/vars.yml
+RC=0
+for test in $ENABLED_TESTS; do
+	ansible-playbook -v --inventory=$ANSIBLE_INVENTORY \
+		--extra-vars "subjects=$TEST_SUBJECTS" \
+		tests/${test}/main.yml > ${TEST_ARTIFACTS}/${test}.log
+        if [ $? -ne 0 ]; then
+		RC=1
+	fi
+done
+popd
+exit $RC

--- a/config/Dockerfiles/package-test/package-test.sh
+++ b/config/Dockerfiles/package-test/package-test.sh
@@ -62,7 +62,10 @@ if [[ -z "${RSYNC_USER}" || -z "${RSYNC_SERVER}" || -z "${RSYNC_DIR}" || -z "${R
          RSYNC_BRANCH=rawhide
      fi
      RSYNC_LOCATION="${RSYNC_USER}@${RSYNC_SERVER}::${RSYNC_DIR}/${RSYNC_BRANCH}"
-     rsync --stats -a ${TEST_ARTIFACTS}/* ${RSYNC_LOCATION}/repo/${package}_repo/logs
+     rm -rf tests/package
+     mkdir -p tests/package
+     cp ${TEST_ARTIFACTS}/* tests/package/
+     rsync --stats -arv tests ${RSYNC_LOCATION}/repo/${package}_repo/logs
 }
 trap clean_up EXIT SIGHUP SIGINT SIGTERM
 


### PR DESCRIPTION
Will have a followup PR later to rename the package-test container to something more general as it encompasses the integration tests as well.  Had to disable three integration tests as they reboot the host and standard-test-roles does not currently support that.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>