### PR TITLE
Checkout rev before running package tests

### DIFF
--- a/config/Dockerfiles/singlehost-test/package-test.sh
+++ b/config/Dockerfiles/singlehost-test/package-test.sh
@@ -43,8 +43,9 @@ fi
 # The specification requires us to invoke the tests in the checkout directory
 pushd ${package}
 
-# Check out the appropriate branch
+# Check out the appropriate branch and rev
 git checkout ${branch}
+git checkout ${rev}
 
 # Check if there is a tests dir from dist-git, if not, exit
 if [ -d tests ]; then


### PR DESCRIPTION
In the current workflow, if the commit in question changes the tests in the dist-git repo, they wouldn't be picked up as we would just be on master.