### PR TITLE
Copy logs to stagename/logs if container fails

### DIFF
--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -602,18 +602,23 @@ def executeInContainer(String stageName, String containerName, String script) {
     // env vars from host. We force them in.
     //
     containerEnv = env.getEnvironment().collect { key, value -> return key+'='+value }
-    withEnv(containerEnv) {
-        container(containerName) {
-            sh 'pwd'
-            sh 'ls -l /tmp'
-            sh "cp -fv ${WORKSPACE}/fedora.keytab /home/fedora.keytab"
-            sh 'env'
-            sh script
-            sh "ls -lR logs || true"
-        }
-    }
     sh "mkdir -p " + stageName
-    sh "mv -vf logs " + stageName + "/logs || true"
+    try {
+        withEnv(containerEnv) {
+            container(containerName) {
+                sh 'pwd'
+                sh 'ls -l /tmp'
+                sh "cp -fv ${WORKSPACE}/fedora.keytab /home/fedora.keytab"
+                sh 'env'
+                sh script
+                sh "ls -lR logs || true"
+            }
+        }
+        sh "mv -vf logs " + stageName + "/logs || true"
+    } catch (err) {
+        sh "mv -vf logs " + stageName + "/logs"
+        throw err
+    }
 }
 
 /**


### PR DESCRIPTION
Currently, if a stage that is executing in a container fails, the logs are archived in Jenkins in the "logs" directory.  We would like that directory to include the stage name, even if the container call failed.  Hopefully, this accomplishes that.  If it passes initial testing, I will have to manually retrigger with a CI_MESSAGE that should fail, to ensure the fix worked.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>