### PR TITLE
Change mock's fs path to use increased pod fs

### DIFF
--- a/config/Dockerfiles/rpmbuild/Dockerfile
+++ b/config/Dockerfiles/rpmbuild/Dockerfile
@@ -39,7 +39,6 @@ RUN for i in {1..5} ; do dnf -y install ansible \
 RUN echo "config_opts['package_manager'] = 'dnf'" >> /etc/mock/site-defaults.cfg
 RUN echo "config_opts['plugin_conf']['lvm_root_opts']['size'] = '16G'" >> /etc/mock/site-defaults.cfg
 RUN echo "config_opts['plugin_conf']['lvm_root_opts']['poolmetadatasize'] = '30G'" >> /etc/mock/site-defaults.cfg
-RUN echo "config_opts['basedir'] = '/home/rpmbuild/'" >> /etc/mock/site-defaults.cfg
 RUN echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 
 # Change the anongiturl for fedpkg

--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -12,6 +12,7 @@ if [ ${CURRENTDIR} == "/" ] ; then
     cd /home
     CURRENTDIR=/home
 fi
+echo "config_opts['basedir'] = '${CURRENTDIR}/rpmbuild/'" >> /etc/mock/site-defaults.cfg
 RPMDIR=/${fed_repo}_repo
 RSYNC_BRANCH=${fed_branch}
 if [ "${fed_branch}" = "master" ]; then


### PR DESCRIPTION
We need mock to use the increased OpenShift filesystem so it can build the kernel. If this passes stage, I will manually trigger it to build a kernel in stage as well before merging to ensure this works.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>