### PR TITLE
UPDATE task for ci-pipeline-ostree-image-boot-sanity

### DIFF
--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -550,6 +550,8 @@ def rsyncData(String stage){
 
     } else if (stage == 'ci-pipeline-ostree-image-boot-sanity') {
         text = text +
+                "export image2boot=\"${env.image2boot}\"\n" +
+                "export commit=\"${env.commit}\"\n" +
                 "export ANSIBLE_HOST_KEY_CHECKING=\"False\"\n"
     } else if (stage == 'ci-pipeline-ostree-boot-sanity') {
         text = text +

--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -497,7 +497,7 @@ def setStageEnvVars(String stage){
 
              ],
              "ci-pipeline-ostree-image-boot-sanity": [
-                     task                     : "./ci-pipeline/tasks/ostree-image-compose",
+                     task                     : "./ci-pipeline/tasks/ostree-boot-image",
                      playbook                 : "ci-pipeline/playbooks/system-setup.yml",
              ],
              "ci-pipeline-ostree-boot-sanity"      : [


### PR DESCRIPTION
Updated task value for ci-pipeline-ostree-image-boot-sanity as it was
pointing to an incorrect value after the jenkinsfile refactor in August.
Mea culpa.