### PR TITLE
Specify ostree-image-compose default libvirt bridge

### DIFF
--- a/config/Dockerfiles/ostree-image-compose/Dockerfile
+++ b/config/Dockerfiles/ostree-image-compose/Dockerfile
@@ -19,6 +19,7 @@ RUN yum -y install dnsmasq libvirt-daemon-driver-* libvirt-daemon \
                    libvirt-daemon-config-network PyYAML wget && yum clean all
 
 RUN git clone https://github.com/CentOS-PaaS-SIG/ci-pipeline
+COPY default.xml /usr/share/libvirt/networks/
 
 COPY ostree-image-compose.sh /tmp/ostree-image-compose.sh
 

--- a/config/Dockerfiles/ostree-image-compose/default.xml
+++ b/config/Dockerfiles/ostree-image-compose/default.xml
@@ -1,0 +1,10 @@
+<network>
+  <name>default</name>
+  <bridge name="image-compose"/>
+  <forward/>
+  <ip address="192.168.122.1" netmask="255.255.255.0">
+    <dhcp>
+      <range start="192.168.122.2" end="192.168.122.254"/>
+    </dhcp>
+  </ip>
+</network>


### PR DESCRIPTION
We should leave virbr0 open for anything that needs it; I don't believe any of our workflow should take that bridge every time.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>