### PR TITLE
Fix lingering /root in rpmbuild container

### DIFF
--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -90,7 +90,7 @@ trap archive_logs EXIT SIGHUP SIGINT SIGTERM
 
 # Build the package into ./results_${fed_repo}/$VERSION/$RELEASE/ and concurrently do a koji build
 { time fedpkg --release ${fed_branch} mockbuild ; } 2> ${LOGDIR}/mockbuild.txt &
-{ time python2 /usr/bin/koji build --wait --arch-override=x86_64 --scratch $RSYNC_BRANCH /root/rpmbuild/SRPMS/${fed_repo}*.src.rpm ; } 2> ${LOGDIR}/kojibuildtime.txt &
+{ time python2 /usr/bin/koji build --wait --arch-override=x86_64 --scratch $RSYNC_BRANCH ~/rpmbuild/SRPMS/${fed_repo}*.src.rpm ; } 2> ${LOGDIR}/kojibuildtime.txt &
 # Set status if either job fails to build the rpm
 MOCKBUILD_RC=0
 for job in `jobs -p`; do


### PR DESCRIPTION
We use ~ for the rpmbuild parent dir, not /root