### PR TITLE
Change ostree-image-compose libvirt bridge

### DIFF
--- a/config/Dockerfiles/ostree-image-compose/default.xml
+++ b/config/Dockerfiles/ostree-image-compose/default.xml
@@ -1,6 +1,6 @@
 <network>
   <name>default</name>
-  <bridge name="image-compose"/>
+  <bridge name="virbr2"/>
   <forward/>
   <ip address="192.168.122.1" netmask="255.255.255.0">
     <dhcp>


### PR DESCRIPTION
The current setting doesn't seem to be working, but it doesn't seem to be complaining either so it was hard to notice.  However, here is output from the latest run:
16:12:39 2017-10-20 16:12:37,744 DEBUG oz.Guest.FedoraGuest thread(921813fd) Message: libvirt bridge name is virbr0

It must not accept the bridge name and just revert back to using virbr0 without raising an error.

@samvarankashyap FYI