### PR TITLE
Run master package tests

### DIFF
--- a/config/Dockerfiles/singlehost-test/package-test.sh
+++ b/config/Dockerfiles/singlehost-test/package-test.sh
@@ -44,8 +44,10 @@ fi
 pushd ${package}
 
 # Check out the appropriate branch and rev
-git checkout ${branch}
-git checkout ${rev}
+#git checkout ${branch}
+#git checkout ${rev}
+# For now, run all master tests as that is the only spot with tests in most packages
+git checkout master
 
 # Check if there is a tests dir from dist-git, if not, exit
 if [ -d tests ]; then


### PR DESCRIPTION
Pretty much all tests that are ported to dist-git are only being put into the master branch. Thus, the f26 and f27 pipelines will almost never run any tests.  Proposing we run the master tests for now, just so tests are being run more often.  The only real negative to this is that we are not verifying the addition to tests to the dist git repo as a change like we would like and if there is a test that runs on master, but not f26, we will be running it anyways. I don't really think that the dist git test addition is ready yet for those scenarios, so this is likely fine for now