### PR TITLE
Stop using /home/output

### DIFF
--- a/config/Dockerfiles/linchpin-libvirt/linchpin_workspace/run_e2e_tests.sh
+++ b/config/Dockerfiles/linchpin-libvirt/linchpin_workspace/run_e2e_tests.sh
@@ -1,5 +1,9 @@
 #!/bin/sh -x
 
+echo "Inserting img_src"
+img_src=$(find /workDir/workspace -name "untested-atomic.qcow2" | tail -n 1)
+sed -i "s|        image_src\:.*|        image_src\: \"file\:\/\/$img_src\"|" /root/linchpin_workspace/topologies/example-topology.yml
+
 echo "Running linchpin up inside libvirt container"
 
 linchpin -v -w /root/linchpin_workspace up


### PR DESCRIPTION
Use the mounted dir instead of /home/output in the containers. Also, stop using dir(ci-pipeline), as that is messing with log archiving. 
@p3ck, I removed the rsync pull of images before ostree-boot-sanity, since we pull it before ostree-image-boot-sanity anyways. Do you think that is okay, or do we require the second rsync? It seems redundant to me.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>