### PR TITLE
Update README.md URL for CI tests specification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ This allowed us to gate packagers in the Fedora infrastructure.
 
 #### Automation Frameworks and Testing in Fedora
 
-Setup and invoking of tests is being done using ansible as outlined in [Invoking Tests Using Ansible](https://fedoraproject.org/wiki/Changes/InvokingTestsAnsible)
+Setup and invoking of tests is being done using ansible as outlined in [Invoking CI Tests](https://fedoraproject.org/wiki/CI/Tests)
 
 #### Design Diagrams
 ![ci-pipeline-complete-view](ci-pipeline-complete-view.png)


### PR DESCRIPTION
https://fedoraproject.org/wiki/Changes/InvokingTestsAnsible holds
deprecated information.

Current CI test specification is located at different URL:
https://fedoraproject.org/wiki/CI/Tests

Signed-off-by: Andrei Stepanov <astepano@redhat.com>