### PR TITLE
Remove diagram for Fedora pieces since this is out of date

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ This allowed us to gate packagers in the Fedora infrastructure.
 Setup and invoking of tests is being done using ansible as outlined in [Invoking CI Tests](https://fedoraproject.org/wiki/CI/Tests)
 
 #### Design Diagrams
-![ci-pipeline-complete-view](ci-pipeline-complete-view.png)
 ![ci-pipeline-detail](ci-pipeline-detail.png) 
 
 #### CI-Pipeline in Action


### PR DESCRIPTION
- No need to include Fedora infrastructure in the document
  this diagram is won't be kept out of date and isn't accurate