### PR TITLE
Remove package test from create-containers.sh

### DIFF
--- a/config/s2i/create-containers.sh
+++ b/config/s2i/create-containers.sh
@@ -27,6 +27,5 @@ oc new-app ostree-compose-builder ${REPO_URL_PARAM} ${REPO_REF_PARAM}
 oc new-app ostree-image-compose-builder ${REPO_URL_PARAM} ${REPO_REF_PARAM}
 oc new-app ostree-boot-image-builder ${REPO_URL_PARAM} ${REPO_REF_PARAM}
 oc new-app singlehost-test-builder ${REPO_URL_PARAM} ${REPO_REF_PARAM}
-oc new-app package-test-builder ${REPO_URL_PARAM} ${REPO_REF_PARAM}
 oc new-app linchpin-libvirt-builder ${REPO_URL_PARAM} ${REPO_REF_PARAM}
 ##


### PR DESCRIPTION
This was added back in by a rebase error in a previous PR.  It is all singlehost container now.