### PR TITLE
Added paas7-openshift-origin36-testing.repo to container

### DIFF
--- a/config/Dockerfiles/linchpin-libvirt/Dockerfile
+++ b/config/Dockerfiles/linchpin-libvirt/Dockerfile
@@ -9,6 +9,7 @@ RUN yum -y install $HOME/epel-release-7-2.noarch.rpm
 
 COPY atomic7-testing.repo /etc/yum.repos.d
 COPY walters-buildtools.repo /etc/yum.repos.d
+COPY paas7-openshift-origin36-testing.repo /etc/yum.repos.d
 
 RUN yum -y install libguestfs libguestfs-tools-c \
                    git ostree rpm-ostree libvirt-client \
@@ -47,7 +48,13 @@ WORKDIR "/tmp/linchpin"
 RUN "$PWD/install.sh"
 RUN cd /tmp/linchpin && python /tmp/linchpin/setup.py install
 WORKDIR "/root/linchpin_workspace/"
-#END: Linchpin sepecific workspace installations
+
+#END: Linchpin specific workspace installations
+
+#START: Install origin-tests rpms
+# installs latest origin-tests rpm
+RUN yum install -y origin-tests
+#END: Linchpin specific workspace installations
 
 RUN yum -y install libvirt-daemon-driver-* libvirt-daemon libvirt-daemon-kvm qemu-kvm socat && yum clean all; \
 (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \

--- a/config/Dockerfiles/linchpin-libvirt/paas7-openshift-origin36-testing.repo
+++ b/config/Dockerfiles/linchpin-libvirt/paas7-openshift-origin36-testing.repo
@@ -1,0 +1,5 @@
+[paas7-openshift-testing]
+name=paas7-openshift-origin36-testing
+baseurl=http://cbs.centos.org/repos/paas7-openshift-origin36-testing/x86_64/os/
+gpgcheck=0
+enabled=1


### PR DESCRIPTION
paas7-openshift-origin36-testing.repo is added to install latest
origin-tests rpm to avoid any further failure due to updates in
origin-tests binaries.