### PR TITLE
FedMsg Relay Pod for dev env

### DIFF
--- a/config/Dockerfiles/fedmsg-relay/Dockerfile
+++ b/config/Dockerfiles/fedmsg-relay/Dockerfile
@@ -1,0 +1,23 @@
+from fedora:25
+
+RUN yum install -y procps net-tools iproute fedmsg-relay && yum clean all -y
+
+EXPOSE 4001
+EXPOSE 2003
+
+RUN useradd fedmsg2 -d /home/fedmsg2 && \
+    mkdir -p /home/fedmsg2/ && \
+    echo "fedmsg2:fedmsg2" | chpasswd
+RUN chmod -R 777 /home/fedmsg2
+
+COPY relay.py /etc/fedmsg.d/relay.py
+COPY ssl.py /etc/fedmsg.d/ssl.py
+COPY endpoints.py /etc/fedmsg.d/endpoints.py
+
+RUN chmod -R 777 /etc/fedmsg.d
+
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+
+ENTRYPOINT ["/bin/sh", "/usr/bin/entrypoint.sh"]
+
+USER fedmsg2

--- a/config/Dockerfiles/fedmsg-relay/endpoints.py
+++ b/config/Dockerfiles/fedmsg-relay/endpoints.py
@@ -1,0 +1,38 @@
+# This file is part of fedmsg.
+# Copyright (C) 2012 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Ralph Bean <rbean@redhat.com>
+#
+config = dict(
+    # This is a dict of possible addresses from which fedmsg can send
+    # messages.  fedmsg.init(...) requires that a 'name' argument be passed
+    # to it which corresponds with one of the keys in this dict.
+    endpoints={
+        # These are here so your local box can listen to the upstream
+        # infrastructure's bus.  Cool, right?  :)
+        #"fedora-infrastructure": [
+        #    "tcp://hub.fedoraproject.org:9940",
+        #    #"tcp://stg.fedoraproject.org:9940",
+        #],
+        #"debian-infrastructure": [
+        #    "tcp://fedmsg.olasd.eu:9940",
+        #],
+        #"anitya-public-relay": [
+        #    "tcp://release-monitoring.org:9940",
+        #],
+    },
+)

--- a/config/Dockerfiles/fedmsg-relay/entrypoint.sh
+++ b/config/Dockerfiles/fedmsg-relay/entrypoint.sh
@@ -1,0 +1,7 @@
+##/usr/sbin/sshd -D -e &
+IP=$(cat /etc/hosts | sed '/^$/d' | tail -1 | awk '{print $1}')
+ls -l /home
+ls -ld /home/fedmsg2
+sed -i -e "s/@@IP@@/$IP/" /etc/fedmsg.d/relay.py
+
+/usr/bin/fedmsg-relay

--- a/config/Dockerfiles/fedmsg-relay/relay.py
+++ b/config/Dockerfiles/fedmsg-relay/relay.py
@@ -1,0 +1,39 @@
+# This file is part of fedmsg.
+# Copyright (C) 2012 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Ralph Bean <rbean@redhat.com>
+#
+
+config = dict(
+    endpoints={
+        # This is the output side of the relay to which all other
+        # services can listen.
+        "relay_outbound": [
+            "tcp://@@IP@@:4001",
+        ],
+    },
+
+    # This is the address of an active->passive relay.  It is used for the
+    # fedmsg-logger command which requires another service with a stable
+    # listening address for it to send messages to.
+    # It is also used by the git-hook, for the same reason.
+    # It is also used by the mediawiki php plugin which, due to the oddities of
+    # php, can't maintain a single passive-bind endpoint of it's own.
+    relay_inbound=[
+        "tcp://@@IP@@:2003",
+    ],
+)

--- a/config/Dockerfiles/fedmsg-relay/ssl.py
+++ b/config/Dockerfiles/fedmsg-relay/ssl.py
@@ -1,0 +1,66 @@
+# This file is part of fedmsg.
+# Copyright (C) 2012 - 2014 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Ralph Bean <rbean@redhat.com>
+#
+import os
+import socket
+
+SEP = os.path.sep
+here = os.getcwd()
+
+config = dict(
+    sign_messages=False,
+    validate_signatures=False,
+
+    # Use these implementations to sign and validate messages
+    crypto_backend='x509',
+    crypto_validate_backends=['x509'],
+
+    ssldir="/etc/pki/fedmsg",
+    crl_location="https://fedoraproject.org/fedmsg/crl.pem",
+    crl_cache="/var/run/fedmsg/crl.pem",
+    crl_cache_expiry=10,
+
+    ca_cert_location="https://fedoraproject.org/fedmsg/ca.crt",
+    ca_cert_cache="/var/run/fedmsg/ca.crt",
+    ca_cert_cache_expiry=0,  # Never expires
+
+    certnames={
+        # In prod/stg, map hostname to the name of the cert in ssldir.
+        # Unfortunately, we can't use socket.getfqdn()
+        #"app01.stg": "app01.stg.phx2.fedoraproject.org",
+    },
+
+    # A mapping of fully qualified topics to a list of cert names for which
+    # a valid signature is to be considered authorized.  Messages on topics not
+    # listed here are considered automatically authorized.
+    routing_policy={
+        # Only allow announcements from production if they're signed by a
+        # certain certificate.
+        "org.fedoraproject.prod.announce.announcement": [
+            "announce-lockbox.phx2.fedoraproject.org",
+        ],
+    },
+
+    # Set this to True if you want messages to be dropped that aren't
+    # explicitly whitelisted in the routing_policy.
+    # When this is False, only messages that have a topic in the routing_policy
+    # but whose cert names aren't in the associated list are dropped; messages
+    # whose topics do not appear in the routing_policy are not dropped.
+    routing_nitpicky=False,
+)

--- a/config/s2i/fedmsg-relay/create-fedmsg-relay.sh
+++ b/config/s2i/fedmsg-relay/create-fedmsg-relay.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z "${REPO_URL}" ] ; then
+  REPO_URL_PARAM=""
+else
+  REPO_URL_PARAM="-p REPO_URL=${REPO_URL}"
+fi
+##
+if [ -z "${REPO_REF}" ] ; then
+  REPO_REF_PARAM=""
+else
+  REPO_REF_PARAM="-p REPO_REF=${REPO_REF}"
+fi
+
+oc create -f fedmsg-relay-template.yaml
+oc new-app fedmsg-relay ${REPO_URL_PARAM} ${REPO_REF_PARAM}

--- a/config/s2i/fedmsg-relay/fedmsg-relay-template.yaml
+++ b/config/s2i/fedmsg-relay/fedmsg-relay-template.yaml
@@ -1,0 +1,135 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: fedmsg-relay
+  creationTimestamp:
+  annotations:
+    openshift.io/display-name: FedMsg Relay
+    description: |-
+      FedMsg Relay
+
+    iconClass: icon-jenkins
+    tags: instant-app,fedmsg-relay
+    template.openshift.io/long-description: This template deploys a FedMsg Relay app.
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+message: A FedMsg Relay app has been created in your project.
+objects:
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    annotations:
+    labels:
+    name: fedmsg-relay
+  spec: {}
+- kind: BuildConfig
+  apiVersion: v1
+  metadata:
+    name: fedmsg-relay
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: fedmsg-relay:latest
+    resources: {}
+    source:
+      contextDir: ${REPO_CONTEXTDIR}
+      git:
+        ref: ${REPO_REF}
+        uri: ${REPO_URL}
+      type: Git
+    strategy:
+      dockerStrategy:
+        env:
+          - name: CONTAINER_NAME
+            value: fedmsg-relay
+      type: Docker
+    triggers:
+    - type: ConfigChange
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: fedmsg-relay
+    name: fedmsg-relay
+  namespace: continuous-infra
+  spec:
+    test: false
+    triggers:
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - "fedmsg-relay"
+          from:
+            kind: ImageStreamTag
+            name: 'fedmsg-relay:latest'
+            namespace: continuous-infra
+      - type: ConfigChange
+    replicas: 1
+    selector:
+      app: fedmsg-relay
+      deploymentconfig: fedmsg-relay
+    strategy:
+      activeDeadlineSeconds: 21600
+      recreateParams:
+        timeoutSeconds: 600
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        annotations:
+          openshift.io/generated-by: OpenShiftWebConsole
+        creationTimestamp: null
+        labels:
+          app: fedmsg-relay
+          deploymentconfig: fedmsg-relay
+      spec:
+        containers:
+        - image: ' '
+          imagePullPolicy: Always
+          name: fedmsg-relay
+          ports:
+          - containerPort: 2003
+            protocol: TCP
+          - containerPort: 4001
+            protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: "fedmsg-relay"
+  spec:
+    ports:
+      - name: 2003-tcp
+        port: 2003
+        protocol: TCP
+        targetPort: 2003
+      - name: 4001-tcp
+        port: 4001
+        protocol: TCP
+        targetPort: 4001
+    selector:
+      deploymentconfig: fedmsg-relay
+    type: ClusterIP
+    sessionAffinity: None
+parameters:
+- description: Git repository with Dockerfile and slave entrypoint.
+  displayName: Repository URL
+  name: REPO_URL
+  value: https://github.com/CentOS-PaaS-SIG/ci-pipeline.git
+- description: The sub-directory inside the repository.
+  displayName: Context Directory
+  name: REPO_CONTEXTDIR
+  value: config/Dockerfiles/fedmsg-relay
+- description: The git ref or tag to use for customization.
+  displayName: Git Reference
+  name: REPO_REF
+  value: master

--- a/config/s2i/jenkins/continuous-infra-create-openshift-project
+++ b/config/s2i/jenkins/continuous-infra-create-openshift-project
@@ -1,7 +1,21 @@
 PROJECT=continuous-infra
+
+if [ -z "${REPO_URL}" ] ; then
+  REPO_URL_PARAM=
+else
+  REPO_URL_PARAM="-p REPO_URL=${REPO_URL}"
+fi
+##
+if [ -z "${REPO_REF}" ] ; then
+  REPO_REF_PARAM=
+else
+  REPO_REF_PARAM="-p REPO_REF=${REPO_REF}"
+fi
+
+
 oc new-project "${PROJECT}" --display-name="${PROJECT}"
 oc policy add-role-to-user edit -z default -n "${PROJECT}"
-oc create -f continuous-infra-jenkins-master-s2i-template.yaml
-oc new-app jenkins-persistent
+oc create -f jenkins-master-template.yaml
+oc new-app jenkins-persistent ${REPO_URL_PARAM} ${REPO_REF_PARAM}
 oc create -f continuous-infra-slave-template.yaml
-oc new-app jenkins-continuous-infra-slave-builder
+oc new-app jenkins-continuous-infra-slave-builder ${REPO_URL_PARAM} ${REPO_REF_PARAM}

--- a/config/s2i/jenkins/continuous-infra-slave-template.yaml
+++ b/config/s2i/jenkins/continuous-infra-slave-template.yaml
@@ -29,10 +29,10 @@ objects:
         name: jenkins-continuous-infra-slave:latest
     resources: {}
     source:
-      contextDir: ${SLAVE_REPO_CONTEXTDIR}
+      contextDir: ${CONTEXTDIR}
       git:
-        ref: ${SLAVE_REPO_REF}
-        uri: ${SLAVE_REPO_URL}
+        ref: ${REPO_REF}
+        uri: ${REPO_URL}
       type: Git
     strategy:
       dockerStrategy:
@@ -42,13 +42,13 @@ objects:
 parameters:
 - description: Git repository with Dockerfile and slave entrypoint.
   displayName: Repository URL
-  name: SLAVE_REPO_URL
+  name: REPO_URL
   value: https://github.com/CentOS-PaaS-SIG/ci-pipeline.git
 - description: The sub-directory inside the repository.
   displayName: Context Directory
-  name: SLAVE_REPO_CONTEXTDIR
+  name: CONTEXTDIR
   value: config/s2i/jenkins/slave
 - description: The git ref or tag to use for customization.
   displayName: Git Reference
-  name: SLAVE_REPO_REF
+  name: REPO_REF
   value: master

--- a/config/s2i/jenkins/jenkins-master-template.yaml
+++ b/config/s2i/jenkins/jenkins-master-template.yaml
@@ -67,8 +67,8 @@ objects:
     source:
       contextDir: ${CONTEXT_DIR}
       git:
-        uri: ${SOURCE_REPOSITORY_URL}
-        ref: ${SOURCE_REPOSITORY_REF}
+        uri: ${REPO_URL}
+        ref: ${REPO_REF}
       secrets: []
       type: Git
     strategy:
@@ -229,11 +229,11 @@ objects:
     sessionAffinity: None
 parameters:
 - description: Git source URI for Jenkins S2I
-  name: SOURCE_REPOSITORY_URL
+  name: REPO_URL
   required: true
   value: https://github.com/CentOS-PaaS-SIG/ci-pipeline.git
 - description: Git branch/tag reference
-  name: SOURCE_REPOSITORY_REF
+  name: REPO_REF
   value: master
 - description: Path within Git project to build; empty for root project directory.
   name: CONTEXT_DIR

--- a/config/s2i/jenkins/master/configuration/init.groovy
+++ b/config/s2i/jenkins/master/configuration/init.groovy
@@ -16,8 +16,12 @@ FedMsgMessagingProvider fedmsg = new FedMsgMessagingProvider("fedora-fedmsg", "t
 GlobalCIConfiguration.get().addMessageProvider(fedmsg)
 
 logger.info("Setup fedora-fedmsg-stage Messaging Provider")
-FedMsgMessagingProvider fedmsgState = new FedMsgMessagingProvider("fedora-fedmsg-stage", "tcp://stg.fedoraproject.org:9940", "tcp://172.19.4.36:9941", "org.fedoraproject");
-GlobalCIConfiguration.get().addMessageProvider(fedmsgState)
+FedMsgMessagingProvider fedmsgStage = new FedMsgMessagingProvider("fedora-fedmsg-stage", "tcp://stg.fedoraproject.org:9940", "tcp://172.19.4.36:9941", "org.fedoraproject");
+GlobalCIConfiguration.get().addMessageProvider(fedmsgStage)
+
+logger.info("Setup fedora-fedmsg-devel Messaging Provider")
+FedMsgMessagingProvider fedmsgDevel = new FedMsgMessagingProvider("fedora-fedmsg-devel", "tcp://fedmsg-relay.continuous-infra.svc:4001", "tcp://fedmsg-relay.continuous-infra.svc:2003", "org.fedoraproject");
+GlobalCIConfiguration.get().addMessageProvider(fedmsgDevel)
 
 logger.info("Setting Time Zone to be EST")
 System.setProperty('org.apache.commons.jelly.tags.fmt.timeZone', 'America/New_York')

--- a/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-receiver-test/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-receiver-test/config.xml
@@ -1,0 +1,34 @@
+
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+    <actions/>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+            <autoRebuild>false</autoRebuild>
+            <rebuildDisabled>false</rebuildDisabled>
+        </com.sonyericsson.rebuild.RebuildSettings>
+    </properties>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers>
+        <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.0.20">
+            <spec></spec>
+            <selector>scott = &quot;true&quot;</selector>
+            <providerName>fedora-fedmsg-devel</providerName>
+            <checks/>
+        </com.redhat.jenkins.plugins.ci.CIBuildTrigger>
+    </triggers>
+    <concurrentBuild>false</concurrentBuild>
+    <builders>
+        <hudson.tasks.Shell>
+            <command>sleep 10</command>
+        </hudson.tasks.Shell>
+    </builders>
+    <publishers/>
+    <buildWrappers/>
+</project>

--- a/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-sender-test/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-sender-test/config.xml
@@ -1,0 +1,30 @@
+
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+            <autoRebuild>false</autoRebuild>
+            <rebuildDisabled>false</rebuildDisabled>
+        </com.sonyericsson.rebuild.RebuildSettings>
+    </properties>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders>
+        <com.redhat.jenkins.plugins.ci.CIMessageBuilder plugin="jms-messaging@1.0.20">
+            <providerName>fedora-fedmsg-devel</providerName>
+            <messageType>Custom</messageType>
+            <messageProperties>scott=true</messageProperties>
+            <messageContent></messageContent>
+            <failOnError>false</failOnError>
+        </com.redhat.jenkins.plugins.ci.CIMessageBuilder>
+    </builders>
+    <publishers/>
+    <buildWrappers/>
+</project>


### PR DESCRIPTION
- new Pod for fedmsg-relay
- hub address is tcp://fedmsg-relay.continuous-infra.svc:4001
- pub address is tcp://fedmsg-relay.continuous-infra.svc:2003
- Jenkins jms messaging provider is called: fedora-fedmsg-devel
- Added 2 new template Jenkins jobs to test functionality: fedmsg-devel-sender-test and fedmsg-devel-receiver-test
- renamed Jenkins templates

Note: call to create-fedmsg-relay.sh needs to be added to ansible dev-setup
