### PR TITLE
Add ability to use python3 for package tests

### DIFF
--- a/config/Dockerfiles/singlehost-test/package-test.sh
+++ b/config/Dockerfiles/singlehost-test/package-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -e
 
 CURRENTDIR=$(pwd)
 if [ ${CURRENTDIR} == "/" ] ; then
@@ -74,10 +74,16 @@ if [ -e inventory ] ; then
     export ANSIBLE_INVENTORY
 fi
 
+PYTHON_INTERPRETER=""
+
+if [[ ! -z "${python3}" && "${python3}" == "yes" ]] ; then
+    PYTHON_INTERPRETER='--extra-vars "ansible_python_interpreter=/usr/bin/python3"'
+fi
+
 # Invoke each playbook according to the specification
 for playbook in tests*.yml; do
 	if [ -f ${playbook} ]; then
-		ansible-playbook --inventory=$ANSIBLE_INVENTORY \
+		ansible-playbook --inventory=$ANSIBLE_INVENTORY $PYTHON_INTERPRETER \
 			--extra-vars "subjects=$TEST_SUBJECTS" \
 			--extra-vars "artifacts=$TEST_ARTIFACTS" \
 			--tags atomic ${playbook}


### PR DESCRIPTION
This is mostly in preparation of the systemd pipeline. If the test subject image has no python, only python3, we will need the ability to pass this in to the playbook command.  This is the case with rawhide images. With this change, we could just define a variable python3=yes pre container call and everything should work.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>