### PR TITLE
Add ability to set minishift base device size

### DIFF
--- a/dev_setup/README.md
+++ b/dev_setup/README.md
@@ -126,6 +126,7 @@ _______
 | profile                 |     Minishift cluster profile name                              | profile=contra-cp                         |   "minishift"                             | No       |
 | disk_size               |     Disk size for minishift                                     | disk_size=25gb                            |   "40gb"                                  | No       |
 | memory                  |     Memory for minishift                                        | memory=4000mb                             |   "6400mb"                                | No       |
+| basedevice_size         |     Base device size for pods in minishift                      | basedevice_size=30G                       |   "20G"                                   | No       |
 | minishift_iso           |     Minishift ISO url location                                  | minishift_iso=[url]                       |   "[ci-pipeline-minishift-iso-url]"       | No       |
 | force_repo_clone        |     Force the clone of the pipeline git repo                    | force_repo_clone=true                     |   true                                    | No       |
 | pipeline_repo           |     Repo to clone for the pipeline                              | pipeline_repo=https://github.com/cip      |   This repo ci-pipeline                   | No       |

--- a/dev_setup/playbooks/group_vars/all/global.yml
+++ b/dev_setup/playbooks/group_vars/all/global.yml
@@ -19,6 +19,10 @@ profile: minishift
 disk_size: 40gb
 memory: 6400mb
 
+# base device size
+# for rootfs in pods
+basedevice_size: 20G
+
 # minishift iso location
 minishift_iso: http://artifacts.ci.centos.org/fedora-atomic/minishift/iso/minishift.iso
 

--- a/dev_setup/playbooks/roles/minishift/defaults/main.yml
+++ b/dev_setup/playbooks/roles/minishift/defaults/main.yml
@@ -11,6 +11,10 @@ profile: minishift
 disk_size: 40gb
 memory: 6400mb
 
+# base device size
+# for rootfs in pods
+basedevice_size: 20G
+
 # minishift iso location
 minishift_iso: http://artifacts.ci.centos.org/fedora-atomic/minishift/iso/minishift.iso
 

--- a/dev_setup/playbooks/roles/minishift/tasks/main.yml
+++ b/dev_setup/playbooks/roles/minishift/tasks/main.yml
@@ -18,6 +18,10 @@
 - name: "Set minishift disk-size {{ memory }}"
   shell: minishift config set memory {{ memory }}
 
+# set base device size
+- name: "Set minishift base device size to {{basedevice_size}}"
+  shell: minishift config set docker-opt "storage-opt=dm.basesize={{basedevice_size}}"
+
 - name: Pull down the minishift iso
   get_url:
     url: "{{ minishift_iso }}"


### PR DESCRIPTION
This will let users configure how large the rootfs needs to
be for pods in minishift