### PR TITLE
Protect against null object errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -277,7 +277,7 @@ podTemplate(name: podName,
                         // Send message org.centos.prod.ci.pipeline.compose.complete on fedmsg
                         pipelineUtils.sendMessageWithAudit(messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
 
-				pipelineUtils.checkLastImage(currentStage)
+                        pipelineUtils.checkLastImage(currentStage)
                     }
 
                     currentStage = "ci-pipeline-ostree-image-compose"
@@ -453,7 +453,6 @@ podTemplate(name: podName,
 
                         // run linchpin workspace for e2e tests
                         //pipelineUtils.executeInContainer(currentStage, "linchpin-libvirt", "/root/linchpin_workspace/run_e2e_tests.sh")
-                        pipelineUtils.executeInContainer(currentStage, "linchpin-libvirt", "date")
                     }
 
                 } catch (e) {

--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -541,8 +541,10 @@ def setStageEnvVars(String stage){
             ]
 
     // Get the map of env var keys and values and write them to the env global variable
-    stages.get(stage).each { key, value ->
-        env."${key}" = value
+    if(stages.containsKey(stage)) {
+        stages.get(stage).each { key, value ->
+            env."${key}" = value
+        }
     }
 }
 


### PR DESCRIPTION
If setStageEnvVars() is the last item in a stage section
and there is no submap for the stage, then Jenkins will throw
a cryptic 'java.io.NotSerializableException: org.codehaus.groovy.runtime.NullObject' error

This is due to the unchecked .get() that otherwise is silently ignored
if another step comes after setStageEnvVars() in a stage.