### PR TITLE
config/s2i/jenkins: rename jenkins bc templates

### DIFF
--- a/config/s2i/jenkins/continuous-infra-create-openshift-project
+++ b/config/s2i/jenkins/continuous-infra-create-openshift-project
@@ -15,7 +15,7 @@ fi
 
 oc new-project "${PROJECT}" --display-name="${PROJECT}"
 oc policy add-role-to-user edit -z default -n "${PROJECT}"
-oc create -f jenkins-master-template.yaml
+oc create -f jenkins-persistent-buildconfig-template.yaml
 oc new-app jenkins-persistent ${REPO_URL_PARAM} ${REPO_REF_PARAM}
-oc create -f continuous-infra-slave-template.yaml
+oc create -f jenkins-continuous-infra-slave-buildconfig-template.yaml
 oc new-app jenkins-continuous-infra-slave-builder ${REPO_URL_PARAM} ${REPO_REF_PARAM}


### PR DESCRIPTION
The patch for adding dev_setup forgot to rename these template files.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>