### PR TITLE
Add necessary changes to add systemd pipeline

### DIFF
--- a/config/Dockerfiles/cloud-image-compose/cloud-image-compose.sh
+++ b/config/Dockerfiles/cloud-image-compose/cloud-image-compose.sh
@@ -32,8 +32,13 @@ virtlogd &
 
 chmod 666 /dev/kvm
 
+imgname="fedora-cloud-rawhide-$package"
+
 function clean_up {
   set +e
+  pushd ${base_dir}/images
+  ln -sf $imgname.qcow2 untested-cloud.qcow2
+  popd
   kill $(jobs -p)
   for screenshot in /var/lib/oz/screenshots/*.ppm; do
       [ -e "$screenshot" ] && cp $screenshot ${base_dir}/logs
@@ -95,7 +100,6 @@ export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
 imagefactory --debug --imgdir $imgdir --timeout 3000 base_image ${base_dir}/logs/fedora-${branch}.tdl --parameter offline_icicle true --file-parameter install_script ${base_dir}/logs/fedora-cloud-base-flat.ks
 
 # convert to qcow
-imgname="fedora-cloud-rawhide-$package"
 qemu-img convert -c -p -O qcow2 $imgdir/*body ${base_dir}/images/$imgname.qcow2
 
 } 2>&1 | tee ${base_dir}/logs/console.log #group for tee

--- a/config/Dockerfiles/inquirer/Dockerfile
+++ b/config/Dockerfiles/inquirer/Dockerfile
@@ -1,0 +1,16 @@
+FROM fedora:26
+LABEL maintainer "https://github.com/CentOS-PaaS-SIG/ci-pipeline"
+LABEL description="This simple container is meant to poll remote_file, \
+exiting when it exists. If the file does not exist after $timeout, \
+the container exits 124.  It also has a script to use repoquery to get \
+the NVR of a package from a remote repo."
+
+RUN yum -y install coreutils \
+        curl \
+        yum-utils \
+        && yum clean all
+
+COPY poller.sh /tmp/poller.sh
+COPY find_nvr.sh /tmp/find_nvr.sh
+
+ENTRYPOINT ["bash", "/tmp/poller.sh"]

--- a/config/Dockerfiles/inquirer/find_nvr.sh
+++ b/config/Dockerfiles/inquirer/find_nvr.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Parameters:
+# package - Package name to get NVR of
+# rpm_repo - Pointer to repo we want to query
+# Returns:
+# package.props with expected=$rpm_nvr
+
+set -ex
+
+base_dir="$( pwd )"
+rm -rf ${base_dir}/logs
+mkdir -p ${base_dir}/logs
+
+# Get NVR
+rpm_nvr=$(repoquery --disablerepo=\* --enablerepo=${package} --repofrompath=${package},${rpm_repo} --nvr ${package})
+echo "expected=$rpm_nvr" > ${base_dir}/logs/package.props

--- a/config/Dockerfiles/inquirer/poller.sh
+++ b/config/Dockerfiles/inquirer/poller.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Parameters:
+# timeout - if this many seconds pass and the file still DNE, exit 1
+# interval - how many seconds to sleep between polls
+# remote_file - file to poll for existence
+
+set -x
+
+i=0
+while [[ "$i" -lt "$timeout" && $(curl -sI $remote_file | grep HTTP) != *"200"* ]]; do
+    i=$((i+interval))
+    sleep $interval
+done

--- a/config/Dockerfiles/singlehost-test/Dockerfile
+++ b/config/Dockerfiles/singlehost-test/Dockerfile
@@ -33,6 +33,8 @@ RUN for i in {1..5} ; do dnf -y install ansible \
 # Copy the build script to the container
 COPY package-test.sh /tmp/package-test.sh
 COPY integration-test.sh /tmp/integration-test.sh
+COPY upstreamfirst-test.sh /tmp/upstreamfirst-test.sh
+COPY main.yml /tmp/beakerlib-role-main.yml
 
 COPY standard-inventory-qcow2 /usr/share/ansible/inventory/standard-inventory-qcow2
 ENV ANSIBLE_INVENTORY=/usr/share/ansible/inventory/standard-inventory-qcow2

--- a/config/Dockerfiles/singlehost-test/main.yml
+++ b/config/Dockerfiles/singlehost-test/main.yml
@@ -1,0 +1,196 @@
+---
+- name: Add executor host
+  add_host:
+    name: executor
+    ansible_connection: local
+    ansible_ssh_host: 127.0.0.1
+    ansible_ssh_connection: local
+- name: Packages to be present on the system.
+  set_fact:
+    # Separate debuginfo and ordinary packages. There is an issue on GitHub:
+    # https://github.com/ansible/ansible/issues/31579. The easiest way to
+    # install debuginfo for package is to use 'debuginfo-install'.  This
+    # program is present on RHEL/CentOS/Fedora and it automatically enables
+    # debuginfo repos.
+    pkgs_ordinary_req: >
+      {{
+        required_packages |
+        reject('match', '.*-debuginfo$') |
+        list
+      }}
+    pkgs_debuginfo_req: >
+      {{
+        required_packages |
+        select('match', '.*-debuginfo$') |
+        list |
+        regex_replace('-debuginfo')
+      }}
+- name: Target OS identification
+  block:
+    - name: Test if system is Atomic Host
+      lineinfile:
+        name: /etc/os-release
+        regexp: .*Atomic Host.*
+        state: absent
+      check_mode: yes
+      changed_when: False
+      register: os_release_atomic
+    - name: Set Ansible fact 'is_atomic_host'
+      set_fact:
+        is_atomic_host: "{{ os_release_atomic.found > 0 }}"
+- block:
+  - name: Gather facts
+    setup:
+    delegate_facts: True
+  - name: Add restraint repo for restraint-rhts on Fedora hosts
+    shell: curl -o /etc/yum.repos.d/bpeck-restraint-fedora-rawhide.repo https://copr.fedorainfracloud.org/coprs/bpeck/restraint/repo/fedora-rawhide/bpeck-restraint-fedora-rawhide.repo
+    when: ansible_distribution == 'Fedora'
+  - name: Add restraint repo for restraint-rhts on RHEL/CentOS hosts
+    block:
+      - package: name=yum-plugin-copr
+      - shell: yum copr -y enable bpeck/restraint
+    when: "[ansible_distribution] | intersect(['RedHat', 'CentOS'])"
+  - name: Install the beakerlib requirements
+    package: name={{item}} state=latest
+    with_items:
+    - beakerlib
+    - restraint-rhts
+    - rsync
+  delegate_to: executor
+- block:
+  - name: Install the beakerlib requirements on target
+    package: name={{item}} state=latest
+    with_items:
+    - rsync
+    - findutils
+  - name: Install any test-specific package requirements
+    # Note, this method cannot install -debuginfo packages.
+    package: name={{item}} state=latest
+    with_items:
+      - "{{ pkgs_ordinary_req }}"
+  - block:
+    - name: Install yum-utils
+      package: name=yum-utils state=latest
+      when: ansible_pkg_mgr == 'yum'
+    - name: Install dnf-utils
+      # System can have installed yum-utils. Which conflicts wih dnf-utils.
+      # Therefore, remove yum-utils and install dnf-utils.
+      shell: dnf --assumeyes --allowerasing install dnf-utils
+      when: ansible_pkg_mgr == 'dnf'
+    - name: Care about debuginfo packages for DNF/YUM systems
+      shell: |
+          debuginfo-install --assumeyes {{item}}
+      with_items:
+          - "{{ pkgs_debuginfo_req }}"
+    when:
+      - "[ansible_pkg_mgr] | intersect(['dnf', 'yum'])"
+      - pkgs_debuginfo_req
+  # Only manually install packages on non atomic hosts
+  when: ansible_pkg_mgr != 'unknown'
+- block:
+  - name: Check presence of required packages for Atomic Host
+    shell: rpm -q {{ pkgs_ordinary_req|join(" ") }}
+    register: package_check
+    changed_when: False
+    failed_when: False
+    args: { warn: no }
+  - name: Install required packages at Atomic Host
+    shell:
+      rpm-ostree install {{ pkgs_ordinary_req|join(" ") }}
+      && rpm-ostree ex livefs
+    when: package_check.rc != 0
+  when:
+    - is_atomic_host
+    - pkgs_ordinary_req
+- name: Define remote_artifacts if it is not already defined
+  set_fact:
+    remote_artifacts: /tmp/artifacts
+  when: remote_artifacts is not defined
+- name: Put beakerlib binaries on the target
+  copy:
+    src: "{{item}}"
+    dest: /usr/local/bin/
+    mode: 755
+  with_fileglob:
+    - "/usr/bin/beakerlib-*"
+    - "/usr/share/beakerlib/*"
+    - "/usr/bin/rhts-*"
+    - "/usr/share/rhts/*"
+    - "/usr/share/rhts/lib/*"
+    - "/usr/bin/rstrnt-*"
+    - "/usr/share/restraint/*"
+    - "rpm.py"
+- name: Copy tests to target
+  synchronize:
+    src: "{{ playbook_dir }}/"
+    dest: /usr/local/bin/
+    ssh_args: "-o UserKnownHostsFile=/dev/null"
+- name: Fix up beakerlib
+  shell: >
+    find /usr/local/bin -type f
+    |
+    xargs sed -i
+    -e 's|/usr/share/beakerlib|/usr/local/bin|g'
+    -e 's|/usr/lib/beakerlib|/usr/local/bin|g'
+    -e 's|/usr/share/rhts/lib/rhts-|/usr/local/bin/rhts-|g'
+    -e 's|/usr/bin/rhts-|/usr/local/bin/rhts-|g'
+    -e 's|/usr/share/rhts/lib/rhts_|/usr/local/bin/rhts-|g'
+    -e 's|/usr/bin/rhts_|/usr/local/bin/rhts-|g'
+    -e 's|/usr/share/rhts-library/rhtslib.sh|/usr/local/bin/beakerlib.sh|g'
+    -e 's|/usr/bin/rstrnt-|/usr/local/bin/rstrnt-|g'
+- name: Make artifacts directory
+  file: path={{ remote_artifacts }} state=directory owner=root mode=755 recurse=yes
+- block:
+  - name: Execute beakerlib tests
+    shell: |
+      export OUTPUTFILE=/dev/stdout TEST={{ item }}
+      logfile={{ remote_artifacts }}/test.$(echo {{ item }} | sed -e 's/\//-/g').log
+      exec 2>>$logfile 1>>$logfile
+      cd /usr/local/bin
+      if [ -f {{ item }} ]; then
+         cd $(dirname {{ item }})
+         /bin/sh -e ./$(basename {{ item }})
+      elif [ -d {{ item }} ]; then
+        cd {{ item }}
+        if [ -f runtest.sh ]; then
+          /bin/sh -e ./runtest.sh
+        elif [ -f Makefile ]; then
+          make run
+        else
+          echo "FAIL don't know how to run test {{ item }}"
+        fi
+      else
+        echo "FAIL test {{ item }} does not appear to be a file or directory"
+      fi
+    with_items:
+    - "{{ tests }}"
+  always:
+  - name: Make the master test summary log artifact
+    shell: |
+      logfile={{ remote_artifacts }}/test.$(echo {{ item }} | sed -e 's/\//-/g').log
+      if grep -q '\[ *FAIL *\]' "$logfile"; then
+        echo "FAIL {{ item }}" >> {{ remote_artifacts }}/test.log
+      elif grep -q '\[ *PASS *\]' "$logfile"; then
+        echo "PASS {{ item }}" >> {{ remote_artifacts }}/test.log
+      elif grep -q FAIL "$logfile"; then
+        echo "FAIL {{ item }}" >> {{ remote_artifacts }}/test.log
+      elif grep -q PASS "$logfile"; then
+        echo "PASS {{ item }}" >> {{ remote_artifacts }}/test.log
+      else
+        echo "UNKNOWN {{ item }}" >> {{ remote_artifacts }}/test.log
+      fi
+    with_items:
+    - "{{ tests }}"
+  - name: Pull out the logs
+    synchronize:
+      dest: "{{ artifacts }}/"
+      src: "{{ remote_artifacts }}/"
+      mode: pull
+      ssh_args: "-o UserKnownHostsFile=/dev/null"
+    when: artifacts|default("") != ""
+  # Can't go in block. See
+  # https://github.com/ansible/ansible/issues/20736
+  - name: Check the results
+    shell: grep "^FAIL" {{ remote_artifacts }}/test.log
+    register: test_fails
+    failed_when: test_fails.stdout or test_fails.stderr

--- a/config/Dockerfiles/singlehost-test/standard-inventory-qcow2
+++ b/config/Dockerfiles/singlehost-test/standard-inventory-qcow2
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import argparse
 import errno
 import json
@@ -14,7 +13,6 @@ import tempfile
 import time
 import traceback
 import distutils.util
-
 IDENTITY = """
 -----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEA1DrTSXQRF8isQQfPfK3U+eFC4zBrjur+Iy15kbHUYUeSHf5S
@@ -44,7 +42,6 @@ f5GS5IuYtBQ1gudBYlSs9fX6T39d2avPsZjfvvSbULXi3OlzWD8sbTtvQPuCaZGI
 Df9PUWMYZ3HRwwdsYovSOkT53fG6guy+vElUEDkrpZYczROZ6GUcx70=
 -----END RSA PRIVATE KEY-----
 """
-
 USER_DATA = """#cloud-config
 users:
   - default
@@ -57,43 +54,34 @@ chpasswd:
     root:foobar
   expire: False
 """
-
 def main(argv):
     parser = argparse.ArgumentParser(description="Inventory for a QCow2 test image")
     parser.add_argument("--list", action="store_true", help="Verbose output")
     parser.add_argument('--host', help="Get host variables")
     parser.add_argument("subjects", nargs="*", default=shlex.split(os.environ.get("TEST_SUBJECTS", "")))
     opts = parser.parse_args()
-
     try:
         if opts.host:
             data = host(opts.host)
         else:
             data = list(opts.subjects)
         sys.stdout.write(json.dumps(data, indent=4, separators=(',', ': ')))
-    except RuntimeError, ex:
+    except RuntimeError as ex:
         sys.stderr.write("{0}: {1}\n".format(os.path.basename(sys.argv[0]), str(ex)))
         return 1
-
     return 0
-
 def list(subjects):
     hosts = [ ]
     variables = { }
     for subject in subjects:
-        if subject.endswith(".qcow2"):
-            sys.stderr.write("calling host\n")
+        if subject.endswith((".qcow2", ".qcow2c")):
             vars = host(subject)
             if vars:
                 hosts.append(subject)
                 variables[subject] = vars
     return { "localhost": { "hosts": hosts, "vars": { } }, "subjects": { "hosts": hosts, "vars": { } }, "_meta": { "hostvars": variables } }
-
-def host(image):
-    null = open(os.devnull, 'w')
-
-    # No name specified, find a port to use
-    for port in range(2222, 5000):
+def start_qemu(image, cloudinit, log, portrange=(2222, 5555)):
+    for port in xrange(*portrange):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
@@ -106,41 +94,42 @@ def host(image):
             sock.close()
     else:
         raise RuntimeError("unable to find free local port to map SSH to")
-
+    return subprocess.Popen(["/usr/bin/qemu-system-x86_64", "-m", "1024", image,
+        "-enable-kvm", "-snapshot", "-cdrom", cloudinit,
+        "-net", "nic,model=virtio", "-net", "user,hostfwd=tcp:127.0.0.3:{0}-:22".format(port),
+        "-device", "isa-serial,chardev=pts2", "-chardev", "file,id=pts2,path=" + log,
+        "-display", "none"], stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT), port
+def host(image):
+    null = open(os.devnull, 'w')
     try:
         tty = os.open("/dev/tty", os.O_WRONLY)
         os.dup2(tty, 2)
     except OSError:
         tty = None
         pass
-
     # A directory for temporary stuff
     directory = tempfile.mkdtemp(prefix="inventory-cloud")
     identity = os.path.join(directory, "identity")
     with open(identity, 'w') as f:
         f.write(IDENTITY)
-    os.chmod(identity, 0600)
+    os.chmod(identity, 0o600)
     metadata = os.path.join(directory, "meta-data")
     with open(metadata, 'w') as f:
         f.write("")
     userdata = os.path.join(directory, "user-data")
     with open(userdata, 'w') as f:
         f.write(USER_DATA)
-
     # Create our cloud init so we can log in
     cloudinit = os.path.join(directory, "cloud-init.iso")
     subprocess.check_call(["/usr/bin/genisoimage", "-input-charset", "utf-8",
                            "-volid", "cidata", "-joliet", "-rock", "-quiet",
                            "-output", cloudinit, userdata, metadata], stdout=null)
-
     # Determine if virtual machine should be kept available for diagnosis after completion
     try:
         diagnose = distutils.util.strtobool(os.getenv("TEST_DEBUG", "0"))
     except ValueError:
         diagnose = 0
-
     sys.stderr.write("Launching virtual machine for {0}\n".format(image))
-
     # And launch the actual VM
     artifacts = os.environ.get("TEST_ARTIFACTS", os.path.join(os.getcwd(), "artifacts"))
     try:
@@ -149,39 +138,45 @@ def host(image):
         if exc.errno != errno.EEXIST or not os.path.isdir(artifacts):
             raise
     log = os.path.join(artifacts, "{0}.log".format(os.path.basename(image)))
-    proc = subprocess.Popen(["/usr/bin/qemu-system-x86_64", "-m", "1024", image,
-        "-enable-kvm", "-snapshot", "-cdrom", cloudinit,
-	"-net", "nic,model=virtio", "-net", "user,hostfwd=tcp:127.0.0.3:{0}-:22".format(port),
-	"-device", "isa-serial,chardev=pts2", "-chardev", "file,id=pts2,path=" + log,
-    "-display", "none"], stdout=open(log, 'a'), stderr=subprocess.STDOUT)
-
-    # The variables
-    variables = {
-        "ansible_ssh_port": "{0}".format(port),
-        "ansible_ssh_host": "127.0.0.3",
-        "ansible_ssh_user": "root",
-        "ansible_ssh_pass": "foobar",
-        "ansible_ssh_private_key_file": identity,
-        "ansible_ssh_common_args": "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
-    }
-
-    # wait for ssh to come up
-    args = " ".join([ "{0}='{1}'".format(*item) for item in variables.items() ])
-    inventory = os.path.join(directory, "inventory")
-    with open(inventory, "w") as f:
-        f.write("{0} {1}\n".format(image, args))
-
-    ping = [
-        "/usr/bin/ansible",
-        "--inventory",
-        inventory,
-        image,
-        "--module-name",
-        "ping"
-    ]
-
-    for tries in range(0, 30):
+    proc = None  # for failure detection
+    cpe = None  # for exception scoping
+    for tries in xrange(0, 5):
         try:
+            proc, port = start_qemu(image, cloudinit, log)
+            break
+        except subprocess.CalledProcessError as cpe:
+            time.sleep(1)
+            continue
+    if proc is None:
+        raise RuntimeError("Could not launch VM for qcow2 image"
+                           " '{0}':{1}".format(image, cpe.output))
+    for tries in xrange(0, 30):
+        try:
+            # The variables
+            variables = {
+                "ansible_ssh_port": "{0}".format(port),
+                "ansible_ssh_host": "127.0.0.3",
+                "ansible_ssh_user": "root",
+                "ansible_ssh_pass": "foobar",
+                "ansible_ssh_private_key_file": identity,
+                "ansible_ssh_common_args": "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+            }
+            # Write out a handy inventory file, for our use and for debugging
+            args = " ".join([ "{0}='{1}'".format(*item) for item in variables.items() ])
+            inventory = os.path.join(directory, "inventory")
+            with open(inventory, "w") as f:
+                f.write("[subjects]\nlocalhost {1}\n".format(image, args))
+            # Wait for ssh to come up
+            ping = [
+                "/usr/bin/ansible",
+                "--inventory",
+                inventory,
+                "localhost",
+                "--module-name",
+                "raw",
+                "--args",
+                "/bin/true"
+            ]
             (pid, ret) = os.waitpid(proc.pid, os.WNOHANG)
             if pid != 0:
                 raise RuntimeError("qemu failed to launch qcow2 image: {0}".format(image))
@@ -190,57 +185,50 @@ def host(image):
         except subprocess.CalledProcessError:
             time.sleep(3)
     else:
+        # Kill the qemu process
+        try:
+            os.kill(proc.pid, signal.SIGTERM)
+        except OSError:
+            pass
         raise RuntimeError("could not access launched qcow2 image: {0}".format(image))
-
     # Process of our parent
     ppid = os.getppid()
-
     child = os.fork()
     if child:
         return variables
-
     # Daemonize and watch the processes
     os.chdir("/")
     os.setsid()
     os.umask(0)
-
     if tty is None:
         tty = null.fileno()
-
     # Duplicate standard input to standard output and standard error.
     os.dup2(null.fileno(), 0)
     os.dup2(tty, 1)
     os.dup2(tty, 2)
-
     # Now wait for the parent process to go away, then kill the VM
     while True:
         time.sleep(3)
-
         try:
             os.kill(ppid, 0)
             os.kill(proc.pid, 0)
         except OSError:
             break # Either of the processes no longer exist
-
     if diagnose:
         sys.stderr.write("\n")
         sys.stderr.write("DIAGNOSE: ssh -p {0} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@{1} # password: {2}\n".format(port, "127.0.0.3", "foobar"))
+        sys.stderr.write("DIAGNOSE: export ANSIBLE_INVENTORY={0}\n".format(inventory))
         sys.stderr.write("DIAGNOSE: kill {0} # when finished\n".format(os.getpid()))
-
         def _signal_handler(*args):
             sys.stderr.write("\nDIAGNOSE ending...\n")
-
         signal.signal(signal.SIGTERM, _signal_handler)
         signal.pause()
-
     # Kill the qemu process
     try:
         os.kill(proc.pid, signal.SIGTERM)
     except OSError:
         pass
-
     shutil.rmtree(directory)
     sys.exit(0)
-
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/config/Dockerfiles/singlehost-test/upstreamfirst-test.sh
+++ b/config/Dockerfiles/singlehost-test/upstreamfirst-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -eux
+
+CURRENTDIR=$(pwd)
+if [ ${CURRENTDIR} == "/" ] ; then
+    cd /home
+    CURRENTDIR=/home
+fi
+export TEST_SUBJECTS=${CURRENTDIR}/untested-atomic.qcow2
+export TEST_ARTIFACTS=${CURRENTDIR}/logs
+# The test artifacts must be an empty directory
+rm -rf ${TEST_ARTIFACTS}
+mkdir -p ${TEST_ARTIFACTS}
+
+# Invoke tests according to section 1.7.2 here:
+# https://fedoraproject.org/wiki/Changes/InvokingTests
+
+if [ -z "${package:-}" ]; then
+	if [ $# -lt 1 ]; then
+		echo "No package defined"
+		exit 2
+	else
+		package="$1"
+	fi
+fi
+
+# Replace beakerlib role with one that won't choke installing restraint while on a rawhide distro
+cp -f /tmp/beakerlib-role-main.yml /etc/ansible/roles/standard-test-beakerlib/tasks/main.yml
+
+# Make sure we have or have downloaded the test subject
+if [ -z "${TEST_SUBJECTS:-}" ]; then
+	echo "No subject defined"
+	exit 2
+elif ! file ${TEST_SUBJECTS:-}; then
+	wget -q -O testimage.qcow2 ${TEST_SUBJECTS}
+	export TEST_SUBJECTS=${PWD}/testimage.qcow2
+fi
+
+# Check out the upstreamfirst repository for this package
+rm -rf ${package}
+if ! git clone https://upstreamfirst.fedorainfracloud.org/${package}; then
+	echo "No upstreamfirst repo for this package! Exiting..."
+	exit 0
+fi
+
+# The specification requires us to invoke the tests in the checkout directory
+pushd ${package}
+
+function clean_up {
+     rm -rf tests/package
+     mkdir -p tests/package
+     cp ${TEST_ARTIFACTS}/* tests/package/
+}
+trap clean_up EXIT SIGHUP SIGINT SIGTERM
+
+# The inventory must be from the test if present (file or directory) or defaults
+if [ -e inventory ] ; then
+    ANSIBLE_INVENTORY=$(pwd)/inventory
+    export ANSIBLE_INVENTORY
+fi
+
+# Invoke each playbook according to the specification
+for playbook in tests*.yml; do
+	if [ -f ${playbook} ]; then
+		ansible-playbook --inventory=$ANSIBLE_INVENTORY \
+                        --extra-vars "ansible_python_interpreter=/usr/bin/python3" \
+			--extra-vars "subjects=$TEST_SUBJECTS" \
+			--extra-vars "artifacts=$TEST_ARTIFACTS" \
+			--tags classic ${playbook}
+	fi
+done
+popd
+popd

--- a/config/s2i/inquirer/inquirer-buildconfig-template.yaml
+++ b/config/s2i/inquirer/inquirer-buildconfig-template.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: inquirer-builder
+metadata:
+  annotations:
+    description: inquirer container
+    iconClass: inquirer
+    tags: instant-app
+  name: inquirer-builder
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    annotations:
+    labels:
+    name: inquirer
+  spec: {}
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: inquirer
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: inquirer:latest
+    resources: {}
+    source:
+      contextDir: ${REPO_CONTEXTDIR}
+      git:
+        ref: ${REPO_REF}
+        uri: ${REPO_URL}
+      type: Git
+    strategy:
+      dockerStrategy:
+        env:
+          - name: CONTAINER_NAME
+            value: inquirer
+      type: Docker
+    triggers:
+    - type: ConfigChange
+parameters:
+- description: Git repository with Dockerfile and slave entrypoint.
+  displayName: Repository URL
+  name: REPO_URL
+  value: https://github.com/CentOS-PaaS-SIG/ci-pipeline.git
+- description: The sub-directory inside the repository.
+  displayName: Context Directory
+  name: REPO_CONTEXTDIR
+  value: config/Dockerfiles/inquirer
+- description: The git ref or tag to use for customization.
+  displayName: Git Reference
+  name: REPO_REF
+  value: master

--- a/playbooks/rpm-verify.yml
+++ b/playbooks/rpm-verify.yml
@@ -1,0 +1,14 @@
+---
+- hosts: '{{ hosts | default("all") }}'
+  become: '{{ become | default("no") }}'
+  become_user: '{{ become_user | default("root") }}'
+  remote_user: '{{ remote_user | default("root") }}'
+  tasks:
+    - name: Get nvr of running rpm
+      command: "rpm -q {{ package }}"
+      register: running
+
+    - name: Fail if nvr's do not match
+      fail:
+        msg: "{{ running.stdout }} is running and does not match {{ expected }}"
+      when: running.stdout != expected


### PR DESCRIPTION
All of these changes are necessary in order to add support for the systemd pipeline.  However, I did not include any of the systemd Jenkinsfile type files, I will in a follow up PR.

Things done in this PR:
- Add sym link to cloud-image-compose script so we have a reliable file to call in the Jenkinsfile
- Add the inquirer container. This container has two scripts: one polls a url, waiting for it to exist, exiting if it does not by $timeout; the second gets the NVR of an rpm using repoquery from a $rpm_repo
- ostree-boot-image changes: Only run the commit verify playbook if $commit is defined; if $expected and $package are both defined, run the rpm-verify playbook (new) that will check that the running nvr of the $package rpm on the host is $expected
- Add a modified beakerlib role main.yml file to the singlehost-test container. This is only used in the upstreamfirst-test.sh script by the container. The point of this is that it hardcodes the location of restraint repo, as rawhide is at time of writing f28, and copr can't build f28 yet. Other than that it is the same as master
- Update standard-inventory-qcow2 in the singlehost-test container. The current one we are storing does not work on cloud hosts. The current one in master from pagure requires tty, so this is a modified version of master which works on both cloud hosts and with no tty
- Add upstreamfirst-test.sh to the singlehost-test container. This script gets the tests from upstreamfirst.fedorainfracloud.org instead of dist-git, as the systemd ask was to pull the tests from there.

Nothing here should break production, but I still would like to see it pass stage just to be doubly sure. 

Signed-off-by: Johnny Bieren <jbieren@redhat.com>