### PR TITLE
Exit poller nonzero if timeout hit

### DIFF
--- a/config/Dockerfiles/inquirer/Dockerfile
+++ b/config/Dockerfiles/inquirer/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:26
 LABEL maintainer "https://github.com/CentOS-PaaS-SIG/ci-pipeline"
 LABEL description="This simple container is meant to poll remote_file, \
 exiting when it exists. If the file does not exist after $timeout, \
-the container exits 124.  It also has a script to use repoquery to get \
+the container exits 1.  It also has a script to use repoquery to get \
 the NVR of a package from a remote repo."
 
 RUN yum -y install coreutils \

--- a/config/Dockerfiles/inquirer/poller.sh
+++ b/config/Dockerfiles/inquirer/poller.sh
@@ -12,3 +12,8 @@ while [[ "$i" -lt "$timeout" && $(curl -sI $remote_file | grep HTTP) != *"200"* 
     i=$((i+interval))
     sleep $interval
 done
+
+# Exit nonzero if we hit timeout
+if [ "$i" -ge "$timeout" ]; then
+    exit 1
+fi


### PR DESCRIPTION
Lost that part of my script with a rework. If the remote_file is never found, we need to exit nonzero once we hit the timeout, as that is kind of the entire point.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>