### PR TITLE
Add all reqs for standard-test-roles Dockerfile

### DIFF
--- a/config/Dockerfiles/singlehost-test/Dockerfile
+++ b/config/Dockerfiles/singlehost-test/Dockerfile
@@ -18,6 +18,8 @@ RUN for i in {1..5} ; do dnf -y install ansible \
         file \
         findutils \
         git \
+        libselinux-python \
+        python2-dnf \
         restraint-rhts \
         rsync \
         standard-test-roles \


### PR DESCRIPTION
I somehow didn't have all the official requirements listed in the Dockerfile install and never hit a bug because they have just always been there luckily, so fixing it to be cleaner.