### PR TITLE
Add dnf-plugins-core to container

### DIFF
--- a/config/Dockerfiles/singlehost-test/Dockerfile
+++ b/config/Dockerfiles/singlehost-test/Dockerfile
@@ -15,6 +15,7 @@ RUN curl -o /etc/yum.repos.d/bpeck-restraint-fedora-26.repo https://copr.fedorai
 RUN for i in {1..5} ; do dnf -y install ansible \
         beakerlib \
         curl \
+        dnf-plugins-core \
         file \
         findutils \
         git \


### PR DESCRIPTION
dnf copr is no longer available with the base install of dnf it seems, so add dnf-plugins-core to get it.