### PR TITLE
Get package list for trigger from upstream

### DIFF
--- a/JenkinsfileTrigger
+++ b/JenkinsfileTrigger
@@ -83,7 +83,7 @@ node('master') {
                             fi
 
 
-                            # Save the bramch in job.properties
+                            # Save the branch in job.properties
                             echo "branch=${branch}" >> ${WORKSPACE}/job.properties
 
                             # Verify this is a branch in our list of targets defined above in the parameters
@@ -93,12 +93,28 @@ node('master') {
                             else
                                 # Verify this is a package we are interested in
                                 valid=0
-                                for package in $(cat ${PROJECT_REPO}/config/package_list); do
-                                    if [ "${package}" = "${fed_repo}" ]; then
-                                        valid=1
-                                        break
-                                    fi
-                                done
+
+                                # Get the upstream package list
+                                rm -rf fedora-atomic
+                                git clone http://pagure.io/fedora-atomic
+                                pushd fedora-atomic
+                                git checkout ${fed_branch}
+                                popd
+
+                                python ${PROJECT_REPO}/utils/package_checker.py ${fed_repo}
+                                CHKR_RC=$?
+                                # If $? -eq 0, we care about package
+                                if [ $CHKR_RC -eq 0 ]; then
+                                    valid=1
+                                # If $? -eq 2, upstream package list didnt exist so use legacy method to check
+                                elif [ $CHKR_RC -eq 2 ]; then
+                                    for package in $(cat ${PROJECT_REPO}/config/package_list); do
+                                        if [ "${package}" = "${fed_repo}" ]; then
+                                            valid=1
+                                            break
+                                        fi
+                                    done
+                                fi
 
                                 if [ $valid -eq 0 ]; then
                                     echo "Not a package we are interested in"

--- a/JenkinsfileTrigger
+++ b/JenkinsfileTrigger
@@ -106,7 +106,7 @@ node('master') {
                                 # If $? -eq 0, we care about package
                                 if [ $CHKR_RC -eq 0 ]; then
                                     valid=1
-                                # If $? -eq 2, upstream package list didnt exist so use legacy method to check
+                                # If $? -eq 2, upstream package list didn't exist so use legacy method to check
                                 elif [ $CHKR_RC -eq 2 ]; then
                                     for package in $(cat ${PROJECT_REPO}/config/package_list); do
                                         if [ "${package}" = "${fed_repo}" ]; then

--- a/utils/package_checker.py
+++ b/utils/package_checker.py
@@ -6,7 +6,7 @@ import os.path
 # Exit 2 if upstream package list doesnt exist
 # Exit 1 if file exists, but package isnt in the list
 
-jsonpath = 'TODO/fedora-atomic-host-base.json'
+jsonpath = 'fedora-atomic/fedora-atomic-host-base.json'
 
 # Make sure json file exists
 if not os.path.isfile(jsonpath):

--- a/utils/package_checker.py
+++ b/utils/package_checker.py
@@ -1,0 +1,27 @@
+#!/bin/env python
+import json
+import sys
+import os.path
+
+# Exit 2 if upstream package list doesnt exist
+# Exit 1 if file exists, but package isnt in the list
+
+jsonpath = 'TODO/fedora-atomic-host-base.json'
+
+# Make sure json file exists
+if not os.path.isfile(jsonpath):
+    print("Could not find upstream package json file")
+    sys.exit(2)
+
+jsonfile = open(jsonpath, 'r').read()
+atomicjson = json.loads(jsonfile)
+mypackage = sys.argv[1]
+
+# Check if package exists in the json file
+# Check both all packages and x86_64 specific packages
+if mypackage in atomicjson["packages"] or mypackage in atomicjson["packages-x86_64"]:
+    print ("Package of interest!")
+    sys.exit(0)
+
+# Fail if not
+sys.exit(1)

--- a/utils/package_checker.py
+++ b/utils/package_checker.py
@@ -1,27 +1,25 @@
-#!/bin/env python
+# !/bin/env python
 import json
 import sys
-import os.path
 
-# Exit 2 if upstream package list doesnt exist
-# Exit 1 if file exists, but package isnt in the list
+# Exit 2 if upstream package list doesn't exist
+# Exit 1 if file exists, but package isn't in the list
+# Exit 0 if file exists, and package is in the list
 
 jsonpath = 'fedora-atomic/fedora-atomic-host-base.json'
 
-# Make sure json file exists
-if not os.path.isfile(jsonpath):
+try:
+    with open(jsonpath, 'r') as f:
+        atomicjson = json.load(f)
+    mypackage = sys.argv[1]
+
+    # Check if package exists in the json file
+    # Check both all packages and x86_64 specific packages
+    if mypackage in atomicjson["packages"] or mypackage in atomicjson["packages-x86_64"]:
+        print ("Package of interest!")
+        sys.exit(0)
+    # Fail if not
+    sys.exit(1)
+except IOError as e:
     print("Could not find upstream package json file")
     sys.exit(2)
-
-jsonfile = open(jsonpath, 'r').read()
-atomicjson = json.loads(jsonfile)
-mypackage = sys.argv[1]
-
-# Check if package exists in the json file
-# Check both all packages and x86_64 specific packages
-if mypackage in atomicjson["packages"] or mypackage in atomicjson["packages-x86_64"]:
-    print ("Package of interest!")
-    sys.exit(0)
-
-# Fail if not
-sys.exit(1)


### PR DESCRIPTION
This will first try to use the upstream package list json to determine if the package is part of atomic. If the checking of upstream fails, it falls back to checking our static list.