### PR TITLE
Fix slave FROM tag and set JVM arch for master

### DIFF
--- a/config/s2i/jenkins/jenkins-persistent-buildconfig-template.yaml
+++ b/config/s2i/jenkins/jenkins-persistent-buildconfig-template.yaml
@@ -135,6 +135,8 @@ objects:
             value: "${ENABLE_OAUTH}"
           - name: OPENSHIFT_ENABLE_REDIRECT_PROMPT
             value: 'true'
+          - name: OPENSHIFT_JENKINS_JVM_ARCH
+            value: 'x86_64'
           - name: KUBERNETES_MASTER
             value: https://kubernetes.default:443
           - name: KUBERNETES_TRUST_CERTIFICATES

--- a/config/s2i/jenkins/slave/Dockerfile
+++ b/config/s2i/jenkins/slave/Dockerfile
@@ -1,4 +1,12 @@
-FROM openshift/jenkins-slave-base-centos7
+FROM openshift/jenkins-slave-base-centos7:v3.6
+##
+## ------------------------------------->  ^^ this is needed
+## since the centosCI openshift cluster
+## is running 3.6 and the slave needs the
+## correct 'oc' binary to work properly
+## This should be updated when the cluster
+## is upgraded.
+##
 RUN yum install -y epel-release
 # add ruby for ghi
 RUN yum install -y ansible jq ruby


### PR DESCRIPTION
Since v3.7 of openshift, there is the possibility for breakage in
backwards compatibilty when using the v3.7 'oc' command with a 'v3.6'
master.

This change forces us to use the v3.6 oc binary

This is a better practice in any event, since we should not be pointing
to a 'latest' tag.

See https://github.com/openshift/jenkins-sync-plugin/issues/173 and https://github.com/openshift/jenkins/issues/477 for details