### PR TITLE
Allow insecure git checkout for Jenkinsfile

### DIFF
--- a/config/s2i/jenkins/jenkins-persistent-buildconfig-template.yaml
+++ b/config/s2i/jenkins/jenkins-persistent-buildconfig-template.yaml
@@ -158,6 +158,8 @@ objects:
                 -XX:+UseParallelGC -XX:MaxPermSize=100m -XX:MinHeapFreeRatio=20
                 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4
                 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=500m
+          - name: GIT_SSL_NO_VERIFY
+            value: 'true'
           resources:
             limits:
               memory: "${MEMORY_LIMIT}"


### PR DESCRIPTION
This has to be done if your Jenkinsfile lives in a repo that your jenkins master cannot securely connect to. Unless there are any drawbacks to this (Scott?), I think we should make this change.