### PR TITLE
Update standard-test-roles before running tests

### DIFF
--- a/config/Dockerfiles/singlehost-test/package-test.sh
+++ b/config/Dockerfiles/singlehost-test/package-test.sh
@@ -12,6 +12,10 @@ export TEST_ARTIFACTS=${CURRENTDIR}/logs
 rm -rf ${TEST_ARTIFACTS}
 mkdir -p ${TEST_ARTIFACTS}
 
+# It was requested that these tests be run with latest rpm of standard-test-roles
+dnf update -y standard-test-roles
+rpm -q standard-test-roles
+
 # Invoke tests according to section 1.7.2 here:
 # https://fedoraproject.org/wiki/Changes/InvokingTests
 


### PR DESCRIPTION
There was a failure due to standard-test-roles being too old in the container, so I was asked to update standard-test-roles to latest each time. Kind of goes against the rules of how OpenShift should work in my opinion, so instead of stripping standard-test-roles from the Dockerfile and doing dnf -y install standard-test-roles in the shell script, I decided to do an update in the script and rpm -q so they can see the version in case there is no update available.