### PR TITLE
Make test_subjects potentially variable in upstreamfirst tests

### DIFF
--- a/config/Dockerfiles/singlehost-test/upstreamfirst-test.sh
+++ b/config/Dockerfiles/singlehost-test/upstreamfirst-test.sh
@@ -6,8 +6,10 @@ if [ ${CURRENTDIR} == "/" ] ; then
     cd /home
     CURRENTDIR=/home
 fi
-export TEST_SUBJECTS=${CURRENTDIR}/untested-atomic.qcow2
 export TEST_ARTIFACTS=${CURRENTDIR}/logs
+if [ -z "${TEST_SUBJECTS:-}" ]; then
+    export TEST_SUBJECTS=${CURRENTDIR}/untested-atomic.qcow2
+fi
 # The test artifacts must be an empty directory
 rm -rf ${TEST_ARTIFACTS}
 mkdir -p ${TEST_ARTIFACTS}


### PR DESCRIPTION
I want to be able to pass in TEST_SUBJECTS and use that instead of always relying on the hardcoded value.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>