### PR TITLE
Add skip stage function

### DIFF
--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -4,6 +4,7 @@ package org.centos.pipeline
 import org.centos.*
 
 import groovy.json.JsonSlurper
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 /**
  * Library to setup and configure the host the way ci-pipeline requires
@@ -1073,4 +1074,13 @@ def checkTests(String mypackage, String mybranch, String tag) {
     echo "Currently checking if package tests exist"
     return sh (returnStatus: true, script: """
     curl -q https://src.fedoraproject.org/rpms/${mypackage}/raw/${mybranch}/f/tests/tests.yml | grep '\\- '${tag}'' """) == 0
+}
+
+/**
+ * Mark stage stageName as skipped
+ * @param stageName
+ * @return
+ */
+def skip(String stageName) {
+    Utils.markStageSkippedForConditional(stageName)
 }

--- a/vars/pipelineUtils.groovy
+++ b/vars/pipelineUtils.groovy
@@ -283,4 +283,13 @@ class pipelineUtils implements Serializable {
         return pipelineUtils.checkTests(mypackage, mybranch, tag)
     }
 
+    /**
+     * Mark stage stageName as skipped
+     * @param stageName
+     * @return
+     */
+    def skip(String stageName) {
+        return pipelineUtils.skip(stageName)
+    }
+
 }


### PR DESCRIPTION
In scripted pipeline, you have no way to mark a stage as skipped like you do in declarative. To my google searching, it simply isn't supported. But, with this function, you can. To do it, you would do something like this
stage('foo') {
    if (skipme) {
        pipelineUtils.skip('foo')
    }
}

@robnester-rh Do I need the import in the vars file too or just the src/..... .groovy file?

Also note that this requires a groovy script approval (for those of you using s2i). It is staticMethod org.jenkinsci.plugins.pipeline.modeldefinition.Utils markStageSkippedForConditional java.lang.String

Signed-off-by: Johnny Bieren <jbieren@redhat.com>