### PR TITLE
Remove docker storage driver setting for minishift

### DIFF
--- a/dev_setup/README.md
+++ b/dev_setup/README.md
@@ -262,7 +262,7 @@ PARAMS:
  4. Setup jenkins infra and pipeline containers.
  5. Don't setup fedmsg relay.
  6. Modify my container tags with the default tag. tag=stable
- 7. Override the pipeline_repo with another one then the default in global.yml
+ 7. Override the pipeline_repo with a fork of ci-pipeline only    
  8. The -K is used to prompt you for your password for sudo (if you require one)
  9. The -k is used to prompt you for your ssh password can hit enter if using -K and they are the same<br>
     _Note: Instead of -k you could use --private-key=<absolute_path_to_ssh_private_key>_
@@ -270,11 +270,8 @@ PARAMS:
 ```
     ansible-playbook -vv -i "localhost," \
     ~/CentOS-PaaS-SIG/ci-pipeline/dev_setup/playbooks/setup.yml \
-    -e remote_user=cloud-user -e skip_prereqs=true -e setup_minishift=true \
-    -e setup_jenkins=true -e setup_containers=true \
-    -e setup_fedmsg=false -e modify_tags=true \
+    -e remote_user=cloud-user -e setup_fedmsg=false \
     -e pipeline_repo=https://github.com/arilivigni/ci-pipeline -K -k
-
 ```
 
 ###### Example 2: Setup on a local server :: Jenkins Infra, fedmsg relay, and pipeline containers
@@ -289,9 +286,8 @@ PARAMS:
 ```
     ansible-playbook -vv -i "localhost," --private-key=/home/cloud-user/my-key \
     ~/CentOS-PaaS-SIG/ci-pipeline/dev_setup/playbooks/setup.yml \
-    -e remote_user=ari -e skip_prereqs=false -e setup_minishift=false \
-    -e setup_jenkins=true -e setup_containers=true \
-    -e setup_fedmsg=true -e modify_tags=false -e force_clone=false -K
+    -e remote_user=ari setup_minishift=false \
+    -e modify_tags=false -e force_clone=false -K
 ```
 
 
@@ -310,9 +306,6 @@ PARAMS:
 ```
     ansible-playbook -vv -i "ci-srv-01.bos.redhat.com," --private-key=/home/cloud-user/my-key \                        
     ~/CentOS-PaaS-SIG/ci-pipeline/dev_setup/playbooks/setup.yml \
-    -e remote_user=cloud-user -e skip_prereqs=true -e setup_minishift=true \
-    -e setup_jenkins=true -e setup_containers=true \
-    -e setup_fedmsg=false -e modify_tags=true -K
-
+    -e remote_user=cloud-user -e skip_prereqs=true -e setup_fedmsg=false -K
 ```
 

--- a/dev_setup/playbooks/roles/minishift/tasks/main.yml
+++ b/dev_setup/playbooks/roles/minishift/tasks/main.yml
@@ -18,10 +18,6 @@
 - name: "Set minishift disk-size {{ memory }}"
   shell: "{{ minishift_dest_dir }}/minishift config set memory {{ memory }}"
 
-# set base device size
-- name: "Set minishift base device size to {{basedevice_size}}"
-  shell: "{{ minishift_dest_dir }}/minishift config set docker-opt 'storage-opt=dm.basesize={{ basedevice_size }}'"
-
 - name: Pull down the minishift iso
   get_url:
     url: "{{ minishift_iso }}"


### PR DESCRIPTION
- Remove setting that allows for containers bigger than 10GB for
  devicemapper (no longer used in newer version of docker)
- Update README - Don't need to have default values on the command line