### PR TITLE
Update JenkinsfileStageTrigger

### DIFF
--- a/JenkinsfileStageTrigger
+++ b/JenkinsfileStageTrigger
@@ -189,13 +189,13 @@ pipeline {
         stage("Run Stage Jobs") {
             failFast true
             parallel {
-                stage("f26 message watcher") {
-                    steps {
-                        script {
-                            pipelineUtils.watchForMessages(MSG_PROVIDER, CANNED_CI_MESSAGES['f26'])
-                        }
-                    }
-                }
+                //stage("f26 message watcher") {
+                    //steps {
+                        //script {
+                            //pipelineUtils.watchForMessages(MSG_PROVIDER, CANNED_CI_MESSAGES['f26'])
+                        //}
+                    //}
+                //}
                 stage("f27 message watcher") {
                     steps {
                         script {
@@ -203,31 +203,31 @@ pipeline {
                         }
                     }
                 }
-                stage("f26 stage job") {
-                    steps {
-                        sleep 30
-                        build job: 'ci-stage-pipeline-f26',
-                                parameters: [
-                                        string(name: 'CI_MESSAGE', value: CANNED_CI_MESSAGES['f26']),
-                                        string(name: 'ghprbActualCommit', value: "${env.ghprbActualCommit}"),
-                                        string(name: 'ghprbGhRepository', value: "${env.ghprbGhRepository}"),
-                                        string(name: 'ghprbPullAuthorLogin', value: "${env.ghprbPullAuthorLogin}"),
-                                        string(name: 'TARGET_BRANCH', value: "f26"),
-                                        string(name: 'sha1', value: "${env.sha1}"),
-                                        string(name: 'ghprbPullId', value: "${env.ghprbPullId}"),
-                                        string(name: 'GENERATE_IMAGE', value: "true"),
-                                        string(name: 'SLAVE_TAG', value: tagMap['jenkins-continuous-infra-slave']),
-                                        string(name: 'RPMBUILD_TAG', value: tagMap['rpmbuild']),
-                                        string(name: 'RSYNC_TAG', value: tagMap['rsync']),
-                                        string(name: 'OSTREE_COMPOSE_TAG', value: tagMap['ostree-compose']),
-                                        string(name: 'OSTREE_IMAGE_COMPOSE_TAG', value: tagMap['ostree-image-compose']),
-                                        string(name: 'SINGLEHOST_TEST_TAG', value: tagMap['singlehost-test']),
-                                        string(name: 'OSTREE_BOOT_IMAGE_TAG', value: tagMap['ostree-boot-image']),
-                                        string(name: 'LINCHPIN_LIBVIRT_TAG', value: tagMap['linchpin-libvirt'])
-                                ],
-                                wait: true
-                    }
-                }
+                //stage("f26 stage job") {
+                    //steps {
+                        //sleep 30
+                        //build job: 'ci-stage-pipeline-f26',
+                                //parameters: [
+                                        //string(name: 'CI_MESSAGE', value: CANNED_CI_MESSAGES['f26']),
+                                        //string(name: 'ghprbActualCommit', value: "${env.ghprbActualCommit}"),
+                                        //string(name: 'ghprbGhRepository', value: "${env.ghprbGhRepository}"),
+                                        //string(name: 'ghprbPullAuthorLogin', value: "${env.ghprbPullAuthorLogin}"),
+                                        //string(name: 'TARGET_BRANCH', value: "f26"),
+                                        //string(name: 'sha1', value: "${env.sha1}"),
+                                        //string(name: 'ghprbPullId', value: "${env.ghprbPullId}"),
+                                        //string(name: 'GENERATE_IMAGE', value: "true"),
+                                        //string(name: 'SLAVE_TAG', value: tagMap['jenkins-continuous-infra-slave']),
+                                        //string(name: 'RPMBUILD_TAG', value: tagMap['rpmbuild']),
+                                        //string(name: 'RSYNC_TAG', value: tagMap['rsync']),
+                                        //string(name: 'OSTREE_COMPOSE_TAG', value: tagMap['ostree-compose']),
+                                        //string(name: 'OSTREE_IMAGE_COMPOSE_TAG', value: tagMap['ostree-image-compose']),
+                                        //string(name: 'SINGLEHOST_TEST_TAG', value: tagMap['singlehost-test']),
+                                        //string(name: 'OSTREE_BOOT_IMAGE_TAG', value: tagMap['ostree-boot-image']),
+                                        //string(name: 'LINCHPIN_LIBVIRT_TAG', value: tagMap['linchpin-libvirt'])
+                                //],
+                                //wait: true
+                    //}
+                //}
                 stage("f27 stage job") {
                     steps {
                         sleep 30


### PR DESCRIPTION
https://koji.fedoraproject.org/koji/search?match=glob&type=build&terms=fedora-atomic-26*

Let's turn off the fedora 26 stage job until fedora 26 is buildable again, because currently the stage job is useless with 26 turned on.