### PR TITLE
Add function for custom build name and description

### DIFF
--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -964,6 +964,20 @@ def updateBuildDisplayAndDescription() {
 }
 
 /**
+ * Sets the Build displayName and Description based on params
+ * @param buildName
+ * @param buildDesc
+ */
+def setCustomBuildNameAndDescription(String buildName, String buildDesc) {
+    if (buildName?.trim()) {
+        currentBuild.displayName = buildName
+    }
+    if (buildDesc?.trim()) {
+        currentBuild.description = buildDesc
+    }
+}
+
+/**
  * get Variables From Message
  * @param message trigger message
  * @return map of message vars

--- a/vars/pipelineUtils.groovy
+++ b/vars/pipelineUtils.groovy
@@ -231,6 +231,15 @@ class pipelineUtils implements Serializable {
         pipelineUtils.updateBuildDisplayAndDescription()
     }
 
+    /**
+     * Sets the Build displayName and Description based on params
+     * @param buildName
+     * @param buildDesc
+     */
+    def setCustomBuildNameAndDescription(String buildName, String buildDesc) {
+        pipelineUtils.setCustomBuildNameAndDescription(buildName, buildDesc)
+    }
+
 /**
  * Check data grepper for presence of a message
  * @param messageID message ID to track.


### PR DESCRIPTION
The current build name and description functions have no flexibility. This one lets us pass in any strings we want

Signed-off-by: Johnny Bieren <jbieren@redhat.com>