### PR TITLE
only trigger atomic pipeline on prod repos

### DIFF
--- a/JenkinsfileTrigger
+++ b/JenkinsfileTrigger
@@ -94,6 +94,13 @@ node('master') {
                                 # Verify this is a package we are interested in
                                 valid=0
 
+                                # Verify this commit is not to a user's fork
+                                if [[ $fed_path == *"repositories/forks"* ]] ; then
+                                    echo "Not interested - Commit to user fork"
+                                    echo "topic=${MAIN_TOPIC}.ci.pipeline.package.ignore" >> ${WORKSPACE}/job.properties
+                                    break
+                                fi
+
                                 # Get the upstream package list
                                 rm -rf fedora-atomic
                                 git clone http://pagure.io/fedora-atomic


### PR DESCRIPTION
Example:
https://apps.fedoraproject.org/datagrepper/id?id=2018-16e4cc3d-4203-47dd-bc24-9ffd5debee9f&is_raw=true&size=extra-large

Signed-off-by: Johnny Bieren <jbieren@redhat.com>