### PR TITLE
Better package discovery

### DIFF
--- a/config/Dockerfiles/cloud-image-compose/Dockerfile
+++ b/config/Dockerfiles/cloud-image-compose/Dockerfile
@@ -24,6 +24,7 @@ RUN yum -y install curl \
         pykickstart \
         PyYAML \
         qemu-kvm \
+        yum-utils \
         && yum clean all
 
 COPY default.xml /etc/libvirt/qemu/networks/

--- a/config/Dockerfiles/cloud-image-compose/cloud-image-compose.sh
+++ b/config/Dockerfiles/cloud-image-compose/cloud-image-compose.sh
@@ -84,7 +84,9 @@ if [ "$noboot" == "yes" ] ; then
     sed -i "s/^autopart/$autopart_line/" ${base_dir}/logs/fedora-cloud-base-flat.ks
 fi
 # Modify kickstart file to add rpm under test
-sed -i '/^%packages/a '$package'' ${base_dir}/logs/fedora-cloud-base-flat.ks
+for pkg in $(repoquery --disablerepo=\* --enablerepo=${package} --repofrompath=${package},${rpm_repo} --all | rev | cut -d '-' -f 3- | rev ) ; do
+    sed -i '/^%packages/a '$pkg'' ${base_dir}/logs/fedora-cloud-base-flat.ks
+done
 # Add the repo to the kickstart file, based on if repo was remote or not
 if [[ $rpm_repo == /* ]]; then
     CUSTOM_IP=$(ip -o a s eth0 | awk '/inet / { print $4 }' | cut -d '/' -f 1)


### PR DESCRIPTION
Sometimes, the fed_repo isn't the package name, such as with krb5. So, I was asked to discover the rpms to install like this instead.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>