### PR TITLE
If download-build fails, use download task

### DIFF
--- a/config/Dockerfiles/rpmbuild/koji_build_pr.sh
+++ b/config/Dockerfiles/rpmbuild/koji_build_pr.sh
@@ -69,7 +69,7 @@ rm -rf ${RPMDIR}
 mkdir -p ${RPMDIR}
 # Create repo
 pushd ${RPMDIR}
-koji download-task ${SCRATCHID} --logs
+koji download-build --arch=x86_64 --arch=src --arch=noarch --debuginfo --task-id ${SCRATCHID} || koji download-task --arch=x86_64 --arch=src --arch=noarch --logs ${SCRATCHID}
 createrepo .
 popd
 

--- a/config/Dockerfiles/rpmbuild/pull_old_task.sh
+++ b/config/Dockerfiles/rpmbuild/pull_old_task.sh
@@ -33,7 +33,7 @@ trap archive_variables EXIT SIGHUP SIGINT SIGTERM
 mkdir somewhere
 pushd somewhere
 # Download koji build so we can archive it
-koji download-build --arch=x86_64 --arch=src --arch=noarch --debuginfo --task-id ${PROVIDED_KOJI_TASKID}
+koji download-build --arch=x86_64 --arch=src --arch=noarch --debuginfo --task-id ${PROVIDED_KOJI_TASKID} || koji download-task --arch=x86_64 --arch=src --arch=noarch --logs ${PROVIDED_KOJI_TASKID}
 createrepo .
 PACKAGE=$(rpm --queryformat "%{NAME}\n" -qp *.src.rpm)
 NVR=$(rpm --queryformat "%{NAME}-%{VERSION}-%{RELEASE}\n" -qp *.src.rpm)

--- a/config/Dockerfiles/rpmbuild/rpmbuild-local.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-local.sh
@@ -71,7 +71,7 @@ rm -rf ${RPMDIR}
 mkdir -p ${RPMDIR}
 # Create repo
 pushd ${RPMDIR}
-koji download-task ${SCRATCHID} --logs
+koji download-build --arch=x86_64 --arch=src --arch=noarch --debuginfo --task-id ${SCRATCHID} || koji download-task --arch=x86_64 --arch=src --arch=noarch --logs ${SCRATCHID}
 createrepo .
 popd
 


### PR DESCRIPTION
Have seen some weird behavior where download-build --task-id foo fails, but download-task foo works

Signed-off-by: Johnny Bieren <jbieren@redhat.com>