### PR TITLE
Update slave Dockerfile for linchpin release job

### DIFF
--- a/config/s2i/jenkins/slave/Dockerfile
+++ b/config/s2i/jenkins/slave/Dockerfile
@@ -7,6 +7,11 @@ FROM openshift/jenkins-slave-base-centos7:v3.6
 ## This should be updated when the cluster
 ## is upgraded.
 ##
-RUN yum install -y epel-release
+
+# Install dependencies for JenkinsfileRelease
 # add ruby for ghi
-RUN yum install -y ansible jq ruby
+RUN yum install -y epel-release; \
+yum install -y gcc python-devel libyaml-devel \
+python-pip python-setuptools python-wheel python-twine \
+ansible jq ruby && yum clean all && rm -rf /var/cache/yum; \
+pip install -U pip setuptools wheel twine


### PR DESCRIPTION
LinchPin now has a job for doing continuous releases. The Jenkins slave needs to have a few additional packages to run it, however.