### PR TITLE
Update rpm verifier

### DIFF
--- a/config/Dockerfiles/singlehost-test/rpm-verify.yml
+++ b/config/Dockerfiles/singlehost-test/rpm-verify.yml
@@ -1,11 +1,28 @@
 ---
 - hosts: localhost
   tasks:
-    - name: Get nvr of running rpm
-      command: "rpm -q {{ package }}"
-      register: running
-
-    - name: Fail if nvr's do not match
+    - name: Get list of rpms
+      find:
+        paths: "{{ rpm_repo }}"
+        patterns: '*.rpm'
+      register: rpmlist
+    - name: Check which rpms are installed
+      dnf:
+        name: "{{ item.path }}"
+        state: present
+      register: rpmoutput
+      check_mode: yes
+      ignore_errors: yes
+      no_log: yes
+      with_items:
+        - "{{ rpmlist.files }}"
+    - name: See if at least one rpm is installed
+      set_fact:
+        myresult: pass
+      when: item.changed == false and item.failed == false
+      no_log: yes
+      with_items:
+        - "{{ rpmoutput.results }}"
+    - name: Fail if none were installed
       fail:
-        msg: "{{ running.stdout }} is running and does not match {{ expected }}"
-      when: running.stdout != expected
+      when: myresult is not defined

--- a/config/Dockerfiles/singlehost-test/verify-rpm.sh
+++ b/config/Dockerfiles/singlehost-test/verify-rpm.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ex
 
-if [[ -z "${package}" || -z "${expected}" ]]; then
-    echo "package or expected variable not provided. Exiting..."
+if [ -z "${rpm_repo}" ]; then
+    echo "rpm_repo variable not provided. Exiting..."
     exit 1
 fi
 
@@ -10,6 +10,9 @@ if [ -z "${TEST_SUBJECTS}" ]; then
     echo "No test subject defined. Exiting..."
     exit 1
 fi
+
+dnf update -y standard-test-roles
+rpm -q standard-test-roles
 
 set +u
 PYTHON_INTERPRETER=""
@@ -19,8 +22,7 @@ if [[ ! -z "${python3}" && "${python3}" == "yes" ]] ; then
 fi
 set -u
 
-ansible-playbook -v --inventory=${ANSIBLE_INVENTORY} ${PYTHON_INTERPRETER} \
+ansible-playbook --inventory=${ANSIBLE_INVENTORY} ${PYTHON_INTERPRETER} \
 	--extra-vars "subjects=${TEST_SUBJECTS}" \
-	--extra-vars "package=${package}" \
-	--extra-vars "expected=${expected}.x86_64" \
+	--extra-vars "rpm_repo=${rpm_repo}" \
 	/tmp/rpm-verify.yml


### PR DESCRIPTION
We can't use package name to verify rpms because the src rpm name doesn't always match the rpms we install. So instead, provide the location to the rpms and check that at least one rpm from that repo is installed.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>