### PR TITLE
Add better checking in the trigger

### DIFF
--- a/JenkinsfileTrigger
+++ b/JenkinsfileTrigger
@@ -114,7 +114,7 @@ node('master') {
                                 pushd fedora-atomic
                                 popd
 
-                                python ${PROJECT_REPO}/utils/package_checker.py ${fed_repo}
+                                python ${PROJECT_REPO}/utils/package_checker.py ${fed_repo} ${branch}
                                 CHKR_RC=$?
                                 # If $? -eq 0, we care about package
                                 if [ $CHKR_RC -eq 0 ]; then

--- a/JenkinsfileTrigger
+++ b/JenkinsfileTrigger
@@ -114,25 +114,20 @@ node('master') {
                                 pushd fedora-atomic
                                 popd
 
-                                # Check all rpms created from this distgit repo
-                                # If rawhide is turned on for the atomic pipeline, the branch logic in this command will need to be fixed
-                                for packagename in $(koji buildinfo $(koji -q list-tagged --latest ${fed_branch} ${fed_repo} | awk '{print $1}') | egrep '\.rpm$' | rev | cut -d '/' -f 1 | cut -d '-' -f 3- | rev | sort | uniq) ; do
-                                    python ${PROJECT_REPO}/utils/package_checker.py ${packagename}
-                                    CHKR_RC=$?
-                                    # If $? -eq 0, we care about package
-                                    if [ $CHKR_RC -eq 0 ]; then
-                                        valid=1
-                                        break
-                                    # If $? -eq 2, upstream package list didn't exist so use legacy method to check
-                                    elif [ $CHKR_RC -eq 2 ]; then
-                                        for package in $(cat ${PROJECT_REPO}/config/package_list); do
-                                            if [ "${package}" = "${packagename}" ]; then
-                                                valid=1
-                                                break
-                                            fi
-                                        done
-                                    fi
-                                done
+                                python ${PROJECT_REPO}/utils/package_checker.py ${fed_repo}
+                                CHKR_RC=$?
+                                # If $? -eq 0, we care about package
+                                if [ $CHKR_RC -eq 0 ]; then
+                                    valid=1
+                                # If $? -eq 2, upstream package list didn't exist so use legacy method to check
+                                elif [ $CHKR_RC -eq 2 ]; then
+                                    for package in $(cat ${PROJECT_REPO}/config/package_list); do
+                                        if [ "${package}" = "${fed_repo}" ]; then
+                                            valid=1
+                                            break
+                                        fi
+                                    done
+                                fi
 
                                 if [ $valid -eq 0 ]; then
                                     echo "Not a package we are interested in"

--- a/JenkinsfileTrigger
+++ b/JenkinsfileTrigger
@@ -114,20 +114,25 @@ node('master') {
                                 pushd fedora-atomic
                                 popd
 
-                                python ${PROJECT_REPO}/utils/package_checker.py ${fed_repo}
-                                CHKR_RC=$?
-                                # If $? -eq 0, we care about package
-                                if [ $CHKR_RC -eq 0 ]; then
-                                    valid=1
-                                # If $? -eq 2, upstream package list didn't exist so use legacy method to check
-                                elif [ $CHKR_RC -eq 2 ]; then
-                                    for package in $(cat ${PROJECT_REPO}/config/package_list); do
-                                        if [ "${package}" = "${fed_repo}" ]; then
-                                            valid=1
-                                            break
-                                        fi
-                                    done
-                                fi
+                                # Check all rpms created from this distgit repo
+                                # If rawhide is turned on for the atomic pipeline, the branch logic in this command will need to be fixed
+                                for packagename in $(koji buildinfo $(koji -q list-tagged --latest ${fed_branch} ${fed_repo} | awk '{print $1}') | egrep '\.rpm$' | rev | cut -d '/' -f 1 | cut -d '-' -f 3- | rev | sort | uniq) ; do
+                                    python ${PROJECT_REPO}/utils/package_checker.py ${packagename}
+                                    CHKR_RC=$?
+                                    # If $? -eq 0, we care about package
+                                    if [ $CHKR_RC -eq 0 ]; then
+                                        valid=1
+                                        break
+                                    # If $? -eq 2, upstream package list didn't exist so use legacy method to check
+                                    elif [ $CHKR_RC -eq 2 ]; then
+                                        for package in $(cat ${PROJECT_REPO}/config/package_list); do
+                                            if [ "${package}" = "${packagename}" ]; then
+                                                valid=1
+                                                break
+                                            fi
+                                        done
+                                    fi
+                                done
 
                                 if [ $valid -eq 0 ]; then
                                     echo "Not a package we are interested in"

--- a/utils/package_checker.py
+++ b/utils/package_checker.py
@@ -1,6 +1,7 @@
-# !/bin/env python
+#!/bin/env python
 import json
 import sys
+import httplib
 
 # Exit 2 if upstream package list doesn't exist
 # Exit 1 if file exists, but package isn't in the list
@@ -18,8 +19,40 @@ try:
     if mypackage in atomicjson["packages"] or mypackage in atomicjson["packages-x86_64"]:
         print ("Package of interest!")
         sys.exit(0)
-    # Fail if not
-    sys.exit(1)
+    # Check if a package that comes from this distgit repo is in atomic
+    else:
+        # Open up a connection to the PDC
+        pdc_server = httplib.HTTPSConnection('pdc.fedoraproject.org', timeout=10)
+        # Get package name from args
+        mypackage = sys.argv[1]
+        
+        # Set up array of packages
+        childPackages = []
+        # Set first page to pull. We only need the name field, which speeds it up
+        resultPage = "/rest_api/v1/rpms/?arch=x86_64&arch=noarch&fields=name&srpm_name=" + mypackage
+        while resultPage != None:
+            pdc_server.request("GET",resultPage)
+            res = pdc_server.getresponse()
+            if res.status != 200:
+                print("PDC lookup failed for %s" % resultPage)
+                sys.exit(2)
+            pdc_message = res.read()
+            # Convert to json
+            pdc_parsed = json.loads(pdc_message)
+            if 'results' in pdc_parsed:
+                # Add packages to array
+                for package in pdc_parsed['results']:
+                    childPackages = childPackages + [package['name']]
+            # This will be None on the last page
+            resultPage = pdc_parsed['next']
+    # Perform the check
+    if set(atomicjson["packages"]).isdisjoint(childPackages) and set(atomicjson["packages-x86_64"]).isdisjoint(childPackages):
+        # Sets are disjoint so package is not in atomic host
+        sys.exit(1)
+    else:
+        # Sets are not disjoint so package is in atomic host
+        print ("Package of interest!")
+        sys.exit(0)
 except IOError as e:
     print("Could not find upstream package json file")
     sys.exit(2)

--- a/utils/package_checker.py
+++ b/utils/package_checker.py
@@ -21,38 +21,30 @@ try:
         sys.exit(0)
     # Check if a package that comes from this distgit repo is in atomic
     else:
-        # Open up a connection to the PDC
-        pdc_server = httplib.HTTPSConnection('pdc.fedoraproject.org', timeout=10)
-        # Get package name from args
+        # Open up a connection to mdapi
+        mdapi_server = httplib.HTTPSConnection('apps.fedoraproject.org', timeout=10)
+        # Get package name and branch from args
         mypackage = sys.argv[1]
+        mybranch = sys.argv[2]
         
-        # Set up array of packages
-        childPackages = []
-        # Set first page to pull. We only need the name field, which speeds it up
-        resultPage = "/rest_api/v1/rpms/?arch=x86_64&arch=noarch&fields=name&srpm_name=" + mypackage
-        while resultPage != None:
-            pdc_server.request("GET",resultPage)
-            res = pdc_server.getresponse()
-            if res.status != 200:
-                print("PDC lookup failed for %s" % resultPage)
-                sys.exit(2)
-            pdc_message = res.read()
-            # Convert to json
-            pdc_parsed = json.loads(pdc_message)
-            if 'results' in pdc_parsed:
-                # Add packages to array
-                for package in pdc_parsed['results']:
-                    childPackages = childPackages + [package['name']]
-            # This will be None on the last page
-            resultPage = pdc_parsed['next']
-    # Perform the check
-    if set(atomicjson["packages"]).isdisjoint(childPackages) and set(atomicjson["packages-x86_64"]).isdisjoint(childPackages):
-        # Sets are disjoint so package is not in atomic host
-        sys.exit(1)
-    else:
-        # Sets are not disjoint so package is in atomic host
-        print ("Package of interest!")
-        sys.exit(0)
+        resultPage = "/mdapi/" + mybranch + "/pkg/" + mypackage
+        mdapi_server.request("GET",resultPage)
+        res = mdapi_server.getresponse()
+        if res.status != 200:
+            print("mdapi lookup failed for %s" % resultPage)
+            sys.exit(2)
+        mdapi_message = res.read()
+        # Convert to json
+        mdapi_parsed = json.loads(mdapi_message)
+        if "co-packages" in mdapi_parsed:
+            # Perform the check
+            if set(atomicjson["packages"]).isdisjoint(mdapi_parsed["co-packages"]) and set(atomicjson["packages-x86_64"]).isdisjoint(mdapi_parsed["co-packages"]):
+                # Sets are disjoint so package is not in atomic host
+                sys.exit(1)
+            else:
+                # Sets are not disjoint so package is in atomic host
+                print ("Package of interest!")
+                sys.exit(0)
 except IOError as e:
     print("Could not find upstream package json file")
     sys.exit(2)


### PR DESCRIPTION
Currently, if you hear a commit to the cockpit repo for example, you check the atomic host json and say there are no packages named cockpit, so do not trigger. However, there are rpms in atomic host from the cockpit distgit repo, they just aren't named "cockpit," they are "cockpit-foo." So, query the PDC if we don't find it in the json originally to see if the package is one of these examples. This adds ~20 seconds sadly.