### PR TITLE
Add oc build recycler

### DIFF
--- a/config/s2i/jenkins/master/configuration/jobs/recycle-openshift-builds/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/recycle-openshift-builds/config.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<flow-definition plugin="workflow-job@2.17">
+   <actions>
+      <org.jenkinsci.plugins.workflow.multibranch.JobPropertyTrackerAction plugin="workflow-multibranch@2.17">
+         <jobPropertyDescriptors>
+            <string>org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty</string>
+            <string>org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty</string>
+            <string>jenkins.model.BuildDiscarderProperty</string>
+         </jobPropertyDescriptors>
+      </org.jenkinsci.plugins.workflow.multibranch.JobPropertyTrackerAction>
+   </actions>
+   <description />
+   <keepDependencies>false</keepDependencies>
+   <properties>
+      <io.fabric8.jenkins.openshiftsync.BuildConfigProjectProperty plugin="openshift-sync@1.0.7">
+         <uid />
+         <namespace />
+         <name />
+         <resourceVersion />
+      </io.fabric8.jenkins.openshiftsync.BuildConfigProjectProperty>
+      <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.27">
+         <autoRebuild>false</autoRebuild>
+         <rebuildDisabled>false</rebuildDisabled>
+      </com.sonyericsson.rebuild.RebuildSettings>
+      <jenkins.model.BuildDiscarderProperty>
+         <strategy class="hudson.tasks.LogRotator">
+            <daysToKeep>-1</daysToKeep>
+            <numToKeep>15</numToKeep>
+            <artifactDaysToKeep>-1</artifactDaysToKeep>
+            <artifactNumToKeep>15</artifactNumToKeep>
+         </strategy>
+      </jenkins.model.BuildDiscarderProperty>
+      <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty />
+      <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+         <triggers>
+            <hudson.triggers.TimerTrigger>
+               <spec>0 8 * * *</spec>
+            </hudson.triggers.TimerTrigger>
+         </triggers>
+      </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+   </properties>
+   <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.45">
+      <scm class="hudson.plugins.git.GitSCM" plugin="git@3.8.0">
+         <configVersion>2</configVersion>
+         <userRemoteConfigs>
+            <hudson.plugins.git.UserRemoteConfig>
+               <url>https://github.com/CentOS-PaaS-SIG/ci-pipeline.git</url>
+            </hudson.plugins.git.UserRemoteConfig>
+         </userRemoteConfigs>
+         <branches>
+            <hudson.plugins.git.BranchSpec>
+               <name>*/master</name>
+            </hudson.plugins.git.BranchSpec>
+         </branches>
+         <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+         <submoduleCfg class="list" />
+         <extensions />
+      </scm>
+      <scriptPath>utils/recycleOCBuilds</scriptPath>
+      <lightweight>false</lightweight>
+   </definition>
+   <triggers />
+   <disabled>false</disabled>
+</flow-definition>

--- a/utils/recycleOCBuilds
+++ b/utils/recycleOCBuilds
@@ -1,0 +1,30 @@
+#!groovy
+
+properties(
+        [
+                buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '15', daysToKeepStr: '', numToKeepStr: '15')),
+                disableConcurrentBuilds(),
+                pipelineTriggers([cron('0 8 * * *')])
+        ]
+)
+
+def stepName = null
+
+node() {
+
+    timeout(time: 30, unit: 'MINUTES') {
+
+        try {
+            stepName = 'Remove Completed Builds'
+            stage(stepName) {
+                // Garbage collect all completed oc builds with -build in their name
+                sh 'oc delete pod $(oc get pods | grep \' Completed \' | grep \'\\-build\' | awk \'{print $1}\')'
+                currentBuild.result = 'SUCCESS'
+            }
+        } catch (Throwable err) {
+                        currentBuild.description = "Delete Failure"
+                        error "Find and deletion of completed oc builds failed!"
+                        currentBuild.result = 'FAILURE'
+        }
+    }
+}

--- a/utils/recycleOCBuilds
+++ b/utils/recycleOCBuilds
@@ -23,7 +23,7 @@ node() {
             }
         } catch (Throwable err) {
                         currentBuild.description = "Delete Failure"
-                        error "Find and deletion of completed oc builds failed!"
+                        print("Find and deletion of completed oc builds failed!")
                         currentBuild.result = 'FAILURE'
         }
     }


### PR DESCRIPTION
Once a day, this job will remove all builds in the openshift instance with -build in their name that are in the completed state. I didn't do the error state ones in case someone wants to see the log output. I also didn't put any age restrictions because I don't see the point in keeping around a successfully completed build for any time at all.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>