### PR TITLE
Parse more srpms

### DIFF
--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -1409,7 +1409,7 @@ def repoFromRequest(String request, String prefix) {
         def gitMatcher = request =~ /git.+?\/([a-z0-9A-Z_\-\+\.]+?)(?:\.git|\?|#).*/
         def buildMatcher = request =~ /(?:koji-shadow|cli-build).+?\/([a-zA-Z0-9\-_\+\.]+)-.*/
         def pkgMatcher = request =~ /^([a-zA-Z0-9\-_\+\.]+$)/
-        def srpmMatcher = request =~ /.+?\/([a-zA-Z0-9\-_\+]+)-[0-9a-zA-Z\.]+-[0-9\.].+.src.rpm/
+        def srpmMatcher = request =~ /.+?\/([a-zA-Z0-9\.\-_\+]+)-[0-9a-zA-Z\.]+-[0-9\.].+.src.rpm/
 
 
         if (gitMatcher.matches()) {


### PR DESCRIPTION
java-1.8.0-openjdk-1.8.0.172-6.b11.fc27.src.rpm gave us grief. I think because there is a . in the name field. To the best of my knowledge, this will fix it