### PR TITLE
Use srcpkg not pkg

### DIFF
--- a/utils/package_checker.py
+++ b/utils/package_checker.py
@@ -27,7 +27,7 @@ try:
         mypackage = sys.argv[1]
         mybranch = sys.argv[2]
         
-        resultPage = "/mdapi/" + mybranch + "/pkg/" + mypackage
+        resultPage = "/mdapi/" + mybranch + "/srcpkg/" + mypackage
         mdapi_server.request("GET",resultPage)
         res = mdapi_server.getresponse()
         if res.status != 200:


### PR DESCRIPTION
/pkg/ works with cockpit, so I thought it was solved, but not with vim. We need /srcpkg/ instead