### PR TITLE
Use different qcow2 image location

### DIFF
--- a/config/Dockerfiles/cloud-image-compose/virt-customize.sh
+++ b/config/Dockerfiles/cloud-image-compose/virt-customize.sh
@@ -42,8 +42,8 @@ fi
 
 # Temporary work around for broken rawhide image
 if [ $branch == "rawhide" ]; then
-    wget https://kojipkgs.fedoraproject.org/compose/rawhide/Fedora-Rawhide-20180615.n.0/compose/Cloud/x86_64/images/Fedora-Cloud-Base-Rawhide-20180615.n.0.x86_64.qcow2
-    DOWNLOADED_IMAGE_LOCATION=$(pwd)/Fedora-Cloud-Base-Rawhide-20180615.n.0.x86_64.qcow2
+    wget http://artifacts.ci.centos.org/artifacts/fedora-atomic/pipeline/rawhide/images/Fedora-Cloud-Base-Rawhide-20180701.n.0.x86_64.qcow2
+    DOWNLOADED_IMAGE_LOCATION=$(pwd)/Fedora-Cloud-Base-Rawhide-20180701.n.0.x86_64.qcow2
 else
     wget --quiet -r --no-parent -A 'Fedora-Cloud-Base*.qcow2' ${INSTALL_URL}
     DOWNLOADED_IMAGE_LOCATION=$(pwd)/$(find dl.fedoraproject.org -name "*.qcow2" | head -1)


### PR DESCRIPTION
May not need this if the job you have quickly created works as expected

Or maybe we leave this until rawhide starts passing again