### PR TITLE
Set pipefail before running test

### DIFF
--- a/config/Dockerfiles/singlehost-test/package-test.sh
+++ b/config/Dockerfiles/singlehost-test/package-test.sh
@@ -101,13 +101,13 @@ fi
 set -u
 
 # Invoke each playbook according to the specification
-set -x
+set -xo pipefail
 for playbook in tests*.yml; do
 	if [ -f ${playbook} ]; then
 		timeout 4h ansible-playbook -v --inventory=$ANSIBLE_INVENTORY $PYTHON_INTERPRETER \
 			--extra-vars "subjects=$TEST_SUBJECTS" \
 			--extra-vars "artifacts=$TEST_ARTIFACTS" \
-			--tags ${TAG} ${playbook} | tee ${TEST_ARTIFACTS}/${playbook}-run.txt
+			--tags ${TAG} ${playbook} $@ | tee ${TEST_ARTIFACTS}/${playbook}-run.txt
 	fi
 done
 popd


### PR DESCRIPTION
Now that we tee the output, we need pipefail, or else the playbook command will never fail, which breaks our logic for finding if things were unstable or not