### PR TITLE
singlehost-test: expose nvr for tests

### DIFF
--- a/config/Dockerfiles/singlehost-test/package-test.sh
+++ b/config/Dockerfiles/singlehost-test/package-test.sh
@@ -104,9 +104,11 @@ set -u
 set -xo pipefail
 for playbook in tests*.yml; do
 	if [ -f ${playbook} ]; then
+		# TODO: nvr needs to be standardized later in STR
 		timeout 4h ansible-playbook -v --inventory=$ANSIBLE_INVENTORY $PYTHON_INTERPRETER \
 			--extra-vars "subjects=$TEST_SUBJECTS" \
 			--extra-vars "artifacts=$TEST_ARTIFACTS" \
+			--extra-vars "nvr=$nvr" \
 			--tags ${TAG} ${playbook} $@ | tee ${TEST_ARTIFACTS}/${playbook}-run.txt
 	fi
 done


### PR DESCRIPTION
Some of the shared tests need this information. This is a quick fix for
the community. We will later standardize the name.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>