### PR TITLE
Install python2-dnf when necessary

### DIFF
--- a/config/Dockerfiles/singlehost-test/rpm-verify.yml
+++ b/config/Dockerfiles/singlehost-test/rpm-verify.yml
@@ -1,6 +1,11 @@
 ---
 - hosts: localhost
   tasks:
+    - name: Ensure python2-dnf is present on SUT when necessary
+      package:
+        name: python2-dnf
+        state: present
+      when: ansible_pkg_mgr == "dnf"
     - name: Get list of rpms
       find:
         paths: "{{ rpm_repo }}"

--- a/config/Dockerfiles/singlehost-test/rpm-verify.yml
+++ b/config/Dockerfiles/singlehost-test/rpm-verify.yml
@@ -2,9 +2,7 @@
 - hosts: localhost
   tasks:
     - name: Ensure python2-dnf is present on SUT when necessary
-      package:
-        name: python2-dnf
-        state: present
+      shell: "yum -y install python2-dnf"
       when: ansible_pkg_mgr == "dnf"
     - name: Get list of rpms
       find:


### PR DESCRIPTION
I see some failures for python2-dnf not being present on the qcow2 image, which makes the dnf module not work