### PR TITLE
Recycle error pods too

### DIFF
--- a/utils/recycleOCBuilds
+++ b/utils/recycleOCBuilds
@@ -23,6 +23,24 @@ def recycleOldTags() {
     '''
 }
 
+// Delete all pods in Error or Evicted state older than 6 hours
+def recycleErrorPods() {
+    sh '''
+        oc get pods | egrep "Error|Evicted" | while read podname ; do
+            if [[ $(echo $podname | awk '{print $5}') == *"d"* ]] ; then
+                # Pod is days old
+                oc delete pod $(echo $podname | awk '{print $1}')
+            elif [[ $(echo $podname | awk '{print $5}') == *"h"* ]] ; then
+                # Pod is hours old
+                echo $podname | awk '{print $5}' | sed 's/[^0-9]//g' | awk '$1>6' | while read hourPod ; do
+                    # Pod is older than 6 hours
+                    oc delete pod $(echo $podname | awk '{print $1}')
+                done
+            fi
+        done
+    '''
+}
+
 def stepName = null
 
 node() {

--- a/utils/recycleOCBuilds
+++ b/utils/recycleOCBuilds
@@ -54,6 +54,7 @@ node() {
                 sh 'oc delete pod $(oc get pods | grep \' Completed \' | grep \'\\-build\' | awk \'{print $1}\')'
                 // Delete old PR- tags for images
                 recycleOldTags()
+                recycleErrorPods()
                 currentBuild.result = 'SUCCESS'
             }
         } catch (Throwable err) {


### PR DESCRIPTION
Recycles pods in error or evicted state that are older than 6 hours old. Pod life is in m when minutes, then h for hours, then d for days, so I delete if it contains d, and if it contains h I make sure the integer > 6.