### PR TITLE
Remove spaces in pod output

### DIFF
--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -1231,7 +1231,7 @@ def obtainLock(String fileLocation, int duration, String myuuid) {
                 fi
                 storeduuid=\$(cat "${fileLocation}")
                 # Break if stored uuid pod is no longer running
-                if [ \$(oc get pods | grep \${storeduuid} | grep Running) == "" ]; then
+                if [ \$(oc get pods | grep \${storeduuid} | grep Running | sed 's/ //g') == "" ]; then
                     break
                 fi
                 sleep 30


### PR DESCRIPTION
Because the oc get pods has four things in it separated by spaces, so the if statement complains about too many arguments. Since we are just grepping for text anyways, we can just delete all the spaces in the output to avoid wrestling with more quoting and variable expansion.