### PR TITLE
Add clear template names function

### DIFF
--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -4,6 +4,7 @@ package org.centos.pipeline
 import org.centos.*
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateAction
 
 /**
  * Library to setup and configure the host the way ci-pipeline requires
@@ -1058,6 +1059,13 @@ def setCustomBuildNameAndDescription(String buildName, String buildDesc) {
     if (buildDesc?.trim()) {
         currentBuild.description = buildDesc
     }
+}
+
+/**
+ * Clears previous pod template's name to avoid implied nesting
+ */
+def clearTemplateNames() {
+  currentBuild.rawBuild.getAction( PodTemplateAction.class )?.stack?.clear()
 }
 
 /**

--- a/vars/pipelineUtils.groovy
+++ b/vars/pipelineUtils.groovy
@@ -261,6 +261,13 @@ class pipelineUtils implements Serializable {
         pipelineUtils.setCustomBuildNameAndDescription(buildName, buildDesc)
     }
 
+    /**
+     * Clears previous pod template's name to avoid implied nesting
+     */
+    def clearTemplateNames() {
+        pipelineUtils.clearTemplateNames()
+    }
+
 /**
  * Check data grepper for presence of a message
  * @param messageID message ID to track.


### PR DESCRIPTION
If you create podTemplate A then podTemplate B, podTemplate B will include all containers from A unless you call this before B's creation.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>