### PR TITLE
add support for pipeline to use F29 qcow2

### DIFF
--- a/config/Dockerfiles/cloud-image-compose/virt-customize.sh
+++ b/config/Dockerfiles/cloud-image-compose/virt-customize.sh
@@ -29,9 +29,9 @@ fi
 if [ "${branch}" == "rawhide" ]; then
     curl -L -k -O "https://jenkins-continuous-infra.apps.ci.centos.org/job/fedora-rawhide-image-test/lastSuccessfulBuild/artifact/Fedora-Rawhide.qcow2"
     DOWNLOADED_IMAGE_LOCATION="$(pwd)/Fedora-Rawhide.qcow2"
-elif [ "${branch}" -eq 28 ]; then
-    curl -L -k -O "https://jenkins-continuous-infra.apps.ci.centos.org/job/fedora-f28-image-test/lastSuccessfulBuild/artifact/Fedora-28.qcow2"
-    DOWNLOADED_IMAGE_LOCATION="$(pwd)/Fedora-28.qcow2"
+elif [ "${branch}" -ge 28 ]; then
+    curl -L -k -O "https://jenkins-continuous-infra.apps.ci.centos.org/job/fedora-f${branch}-image-test/lastSuccessfulBuild/artifact/Fedora-${branch}.qcow2"
+    DOWNLOADED_IMAGE_LOCATION="$(pwd)/Fedora-${branch}.qcow2"
 else
     INSTALL_URL="https://dl.fedoraproject.org/pub/fedora/linux/releases/${branch}/CloudImages/x86_64/images/"
     wget --quiet -r --no-parent -A 'Fedora-Cloud-Base*.qcow2' ${INSTALL_URL}


### PR DESCRIPTION
F29 upstream pipeline should use qcow2 from https://jenkins-continuous-infra.apps.ci.centos.org/view/all/job/fedora-f29-image-test/lastSuccessfulBuild/artifact/Fedora-29.qcow2