### PR TITLE
nvr check saves list of installed packages

### DIFF
--- a/config/Dockerfiles/singlehost-test/rpm-verify.yml
+++ b/config/Dockerfiles/singlehost-test/rpm-verify.yml
@@ -1,32 +1,24 @@
 ---
 - hosts: localhost
   tasks:
-    - name: Ensure python2-dnf is present on SUT when necessary
-      shell: "yum -y install python2-dnf"
-      when: (ansible_pkg_mgr == "dnf" and ansible_distribution == "Fedora")
-    - name: Ensure python3-dnf is present on SUT when necessary
-      shell: "dnf -y install python3-dnf"
-      when: (ansible_pkg_mgr == "dnf" and ansible_python_interpreter == "/usr/bin/python3")
-    - name: Get list of rpms
-      find:
-        paths: "{{ rpm_repo }}"
-        patterns: '*.rpm'
-      register: rpmlist
-    - name: Check which rpms are installed
-      package:
-        name: "{{ item.path }}"
-        state: present
-      register: rpmoutput
-      check_mode: yes
-      ignore_errors: yes
-      with_items:
-        - "{{ rpmlist.files }}"
-    - name: See if at least one rpm is installed
-      set_fact:
-        myresult: pass
-      when: item.changed == false and item.failed == false
-      with_items:
-        - "{{ rpmoutput.results }}"
-    - name: Fail if none were installed
-      fail:
-      when: myresult is not defined
+    - name: Save list of installed rpms
+      shell: "rpm -qa | sort > installed_rpms.txt"
+      args:
+        warn: false
+    - name: Fetch installed rpms file to {{ artifacts }}
+      fetch:
+        src: installed_rpms.txt
+        dest: "{{ artifacts }}/installed_rpms.txt"
+        flat: yes
+    - name: Check if rpm from repo is installed
+      shell: |
+        # Get list of packages from rpm repo
+        rpmlist_repo=$(ls {{ rpm_repo }} | grep -e "\.rpm$" | sed 's/\.rpm$//')
+        # if at least one package from repo is installed NVR check passes
+        for rpm in ${rpmlist_repo}; do
+            if grep $rpm installed_rpms.txt; then
+                exit 0
+            fi
+        done
+        echo "FAIL: didn't find correct package installed."
+        exit 1


### PR DESCRIPTION
This should make easier to debug in case some package is not installed.

Example of current playbook output:

    + ansible-playbook -v --inventory=/usr/share/ansible/inventory/standard-inventory-qcow2 --extra-vars subjects=/workDir/workspace/fedora-rawhide-build-pipeline/images/test_subject.qcow2 --extra-vars artifacts=/workDir/workspace/fedora-rawhide-build-pipeline/logs --extra-vars rpm_repo=/etc/yum.repos.d/standard-test-roles /tmp/rpm-verify.yml
    ++ pwd
    + tee /workDir/workspace/fedora-rawhide-build-pipeline/logs/rpm-verify-out.txt
    Using /etc/ansible/ansible.cfg as config file

    PLAY [localhost] ***************************************************************

    TASK [Gathering Facts] *********************************************************
    ok: [/workDir/workspace/fedora-rawhide-build-pipeline/images/test_subject.qcow2]

    TASK [Ensure python2-dnf is present on SUT when necessary] *********************
    [WARNING]: Consider using the yum module rather than running yum.  If you need
    to use command because yum is insufficient you can add warn=False to this
    command task or set command_warnings=False in ansible.cfg to get rid of this
    message.
    changed: [/workDir/workspace/fedora-rawhide-build-pipeline/images/test_subject.qcow2] => {"changed": true, "cmd": "yum -y install python2-dnf", "delta": "0:00:37.056156", "end": "2018-09-03 11:02:18.023806", "rc": 0, "start": "2018-09-03 11:01:40.967650", "stderr": "", "stderr_lines": [], "stdout": "test-standard-test-roles                         59 kB/s | 1.8 kB     00:00    \nFedora - Modular Rawhide - Developmental packag 2.2 MB/s | 1.2 MB     00:00    \nFedora - Rawhide - Developmental packages for t  25 MB/s |  62 MB     00:02    \nLast metadata expiration check: 0:00:00 ago on Mon 03 Sep 2018 11:01:44 AM UTC.\nDependencies resolved.\n================================================================================\n Package                   Arch        Version               Repository    Size\n================================================================================\nInstalling:\n python2-dnf               noarch      3.2.0-2.fc29          rawhide      423 k\nInstalling dependencies:\n pyliblzma                 x86_64      0.5.3-24.fc29         rawhide       54 k\n python2-gobject-base      x86_64      3.29.2-1.fc29         rawhide      306 k\n python2-gpg               x86_64      1.11.1-3.fc29         rawhide      233 k\n python2-hawkey            x86_64      0.17.0-2.fc29         rawhide       70 k\n python2-iniparse          noarch      0.4-32.fc29           rawhide       42 k\n python2-libcomps          x86_64      0.1.8-14.fc29         rawhide       46 k\n python2-libdnf            x86_64      0.17.0-2.fc29         rawhide      423 k\n python2-librepo           x86_64      1.9.1-1.fc29          rawhide       46 k\n python2-rpm               x86_64      4.14.2-1.fc30         rawhide       72 k\n python2-six               noarch      1.11.0-6.fc29         rawhide       34 k\n python2-smartcols         x86_64      0.3.0-4.fc29          rawhide      107 k\n\nTransaction Summary\n================================================================================\nInstall  12 Packages\n\nTotal download size: 1.8 M\nInstalled size: 8.2 M\nDownloading Packages:\n[MIRROR] pyliblzma-0.5.3-24.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: c65bd8891ab4e7a9a614e1c19c212801bca514da70fc75324f44d9bbdb059a12(sha256)  Expected: b77e155b9a06ce6a55aed2f2ae3552025a06d465287e6580c7689dae3a612573(sha256) \n(1/12): python2-gobject-base-3.29.2-1.fc29.x86_ 1.4 MB/s | 306 kB     00:00    \n(2/12): python2-dnf-3.2.0-2.fc29.noarch.rpm     1.9 MB/s | 423 kB     00:00    \n[MIRROR] pyliblzma-0.5.3-24.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: c65bd8891ab4e7a9a614e1c19c212801bca514da70fc75324f44d9bbdb059a12(sha256)  Expected: b77e155b9a06ce6a55aed2f2ae3552025a06d465287e6580c7689dae3a612573(sha256) \n(3/12): python2-hawkey-0.17.0-2.fc29.x86_64.rpm 1.1 MB/s |  70 kB     00:00    \n[MIRROR] python2-gpg-1.11.1-3.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: ea308bac8f4ae330e394d14b8a6b238e7c3c1d435ff505a63b6d4ddbb73251c2(sha256)  Expected: ddf83d33a047211c02324374ae43064fbc96fc156ce5284bf45579cd43c3588c(sha256) \n[MIRROR] python2-iniparse-0.4-32.fc29.noarch.rpm: Downloading successful, but checksum doesn't match. Calculated: 9a74056bee66742aa6600cd78acd9ab419e1278d5aa14a69272d34b5b94870fc(sha256)  Expected: 4573120918010b05f7b2bf8c49b5ade1852e7208e3f2075bf511b554f3410cbf(sha256) \n[MIRROR] python2-gpg-1.11.1-3.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: ea308bac8f4ae330e394d14b8a6b238e7c3c1d435ff505a63b6d4ddbb73251c2(sha256)  Expected: ddf83d33a047211c02324374ae43064fbc96fc156ce5284bf45579cd43c3588c(sha256) \n[MIRROR] python2-iniparse-0.4-32.fc29.noarch.rpm: Downloading successful, but checksum doesn't match. Calculated: 9a74056bee66742aa6600cd78acd9ab419e1278d5aa14a69272d34b5b94870fc(sha256)  Expected: 4573120918010b05f7b2bf8c49b5ade1852e7208e3f2075bf511b554f3410cbf(sha256) \n(4/12): pyliblzma-0.5.3-24.fc29.x86_64.rpm       68 kB/s |  54 kB     00:00    \n[MIRROR] python2-libcomps-0.1.8-14.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: 8bf1e963bd80452eb7d7a9c607fa0902ca7521ae7b79350c23301cb868775722(sha256)  Expected: 2bb7ea444a3b75059a83e72e228e07d4d0ac898a24c52a43df24cd16159af6b8(sha256) \n[MIRROR] python2-libcomps-0.1.8-14.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: 8bf1e963bd80452eb7d7a9c607fa0902ca7521ae7b79350c23301cb868775722(sha256)  Expected: 2bb7ea444a3b75059a83e72e228e07d4d0ac898a24c52a43df24cd16159af6b8(sha256) \n(5/12): python2-iniparse-0.4-32.fc29.noarch.rpm  59 kB/s |  42 kB     00:00    \n(6/12): python2-gpg-1.11.1-3.fc29.x86_64.rpm    293 kB/s | 233 kB     00:00    \n(7/12): python2-libcomps-0.1.8-14.fc29.x86_64.r 189 kB/s |  46 kB     00:00    \n(8/12): python2-librepo-1.9.1-1.fc29.x86_64.rpm 963 kB/s |  46 kB     00:00    \n(9/12): python2-libdnf-0.17.0-2.fc29.x86_64.rpm 6.5 MB/s | 423 kB     00:00    \n(10/12): python2-rpm-4.14.2-1.fc30.x86_64.rpm   1.2 MB/s |  72 kB     00:00    \n[MIRROR] python2-six-1.11.0-6.fc29.noarch.rpm: Downloading successful, but checksum doesn't match. Calculated: cdd32b90c7457600c569cde67e607a9a4f1eeb7ba4405aae8fe9fc4da168245e(sha256)  Expected: 86955d3ab54b9e366c328e56b561aea63ddbf924b4f11aaea227d6bbcd8017f1(sha256) \n[MIRROR] python2-smartcols-0.3.0-4.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: 5b4ae9ec46fc834db524566edf982651bc1a1e33bd7b54f09302620568d4d6c5(sha256)  Expected: 70429ae1ab5b309699ecc2acb1be32a1cc5579fb9cd43b8ebb5e6af9ef18b6ae(sha256) \n(11/12): python2-six-1.11.0-6.fc29.noarch.rpm   147 kB/s |  34 kB     00:00    \n(12/12): python2-smartcols-0.3.0-4.fc29.x86_64. 453 kB/s | 107 kB     00:00    \n--------------------------------------------------------------------------------\nTotal                                           1.3 MB/s | 1.8 MB     00:01     \nRunning transaction check\nTransaction check succeeded.\nRunning transaction test\nTransaction test succeeded.\nRunning transaction\n  Preparing        :                                                        1/1 \n  Installing       : python2-libdnf-0.17.0-2.fc29.x86_64                   1/12 \n  Installing       : python2-hawkey-0.17.0-2.fc29.x86_64                   2/12 \n  Installing       : python2-smartcols-0.3.0-4.fc29.x86_64                 3/12 \n  Installing       : python2-six-1.11.0-6.fc29.noarch                      4/12 \n  Installing       : python2-iniparse-0.4-32.fc29.noarch                   5/12 \n  Installing       : python2-rpm-4.14.2-1.fc30.x86_64                      6/12 \n  Installing       : python2-librepo-1.9.1-1.fc29.x86_64                   7/12 \n  Installing       : python2-libcomps-0.1.8-14.fc29.x86_64                 8/12 \n  Installing       : python2-gpg-1.11.1-3.fc29.x86_64                      9/12 \n  Installing       : python2-gobject-base-3.29.2-1.fc29.x86_64            10/12 \n  Installing       : pyliblzma-0.5.3-24.fc29.x86_64                       11/12 \n  Installing       : python2-dnf-3.2.0-2.fc29.noarch                      12/12 \n  Running scriptlet: python2-dnf-3.2.0-2.fc29.noarch                      12/12 \n  Verifying        : pyliblzma-0.5.3-24.fc29.x86_64                        1/12 \n  Verifying        : python2-dnf-3.2.0-2.fc29.noarch                       2/12 \n  Verifying        : python2-gobject-base-3.29.2-1.fc29.x86_64             3/12 \n  Verifying        : python2-gpg-1.11.1-3.fc29.x86_64                      4/12 \n  Verifying        : python2-hawkey-0.17.0-2.fc29.x86_64                   5/12 \n  Verifying        : python2-iniparse-0.4-32.fc29.noarch                   6/12 \n  Verifying        : python2-libcomps-0.1.8-14.fc29.x86_64                 7/12 \n  Verifying        : python2-libdnf-0.17.0-2.fc29.x86_64                   8/12 \n  Verifying        : python2-librepo-1.9.1-1.fc29.x86_64                   9/12 \n  Verifying        : python2-rpm-4.14.2-1.fc30.x86_64                     10/12 \n  Verifying        : python2-six-1.11.0-6.fc29.noarch                     11/12 \n  Verifying        : python2-smartcols-0.3.0-4.fc29.x86_64                12/12 \n\nInstalled:\n  python2-dnf-3.2.0-2.fc29.noarch                                               \n  pyliblzma-0.5.3-24.fc29.x86_64                                                \n  python2-gobject-base-3.29.2-1.fc29.x86_64                                     \n  python2-gpg-1.11.1-3.fc29.x86_64                                              \n  python2-hawkey-0.17.0-2.fc29.x86_64                                           \n  python2-iniparse-0.4-32.fc29.noarch                                           \n  python2-libcomps-0.1.8-14.fc29.x86_64                                         \n  python2-libdnf-0.17.0-2.fc29.x86_64                                           \n  python2-librepo-1.9.1-1.fc29.x86_64                                           \n  python2-rpm-4.14.2-1.fc30.x86_64                                              \n  python2-six-1.11.0-6.fc29.noarch                                              \n  python2-smartcols-0.3.0-4.fc29.x86_64                                         \n\nComplete!", "stdout_lines": ["test-standard-test-roles                         59 kB/s | 1.8 kB     00:00    ", "Fedora - Modular Rawhide - Developmental packag 2.2 MB/s | 1.2 MB     00:00    ", "Fedora - Rawhide - Developmental packages for t  25 MB/s |  62 MB     00:02    ", "Last metadata expiration check: 0:00:00 ago on Mon 03 Sep 2018 11:01:44 AM UTC.", "Dependencies resolved.", "================================================================================", " Package                   Arch        Version               Repository    Size", "================================================================================", "Installing:", " python2-dnf               noarch      3.2.0-2.fc29          rawhide      423 k", "Installing dependencies:", " pyliblzma                 x86_64      0.5.3-24.fc29         rawhide       54 k", " python2-gobject-base      x86_64      3.29.2-1.fc29         rawhide      306 k", " python2-gpg               x86_64      1.11.1-3.fc29         rawhide      233 k", " python2-hawkey            x86_64      0.17.0-2.fc29         rawhide       70 k", " python2-iniparse          noarch      0.4-32.fc29           rawhide       42 k", " python2-libcomps          x86_64      0.1.8-14.fc29         rawhide       46 k", " python2-libdnf            x86_64      0.17.0-2.fc29         rawhide      423 k", " python2-librepo           x86_64      1.9.1-1.fc29          rawhide       46 k", " python2-rpm               x86_64      4.14.2-1.fc30         rawhide       72 k", " python2-six               noarch      1.11.0-6.fc29         rawhide       34 k", " python2-smartcols         x86_64      0.3.0-4.fc29          rawhide      107 k", "", "Transaction Summary", "================================================================================", "Install  12 Packages", "", "Total download size: 1.8 M", "Installed size: 8.2 M", "Downloading Packages:", "[MIRROR] pyliblzma-0.5.3-24.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: c65bd8891ab4e7a9a614e1c19c212801bca514da70fc75324f44d9bbdb059a12(sha256)  Expected: b77e155b9a06ce6a55aed2f2ae3552025a06d465287e6580c7689dae3a612573(sha256) ", "(1/12): python2-gobject-base-3.29.2-1.fc29.x86_ 1.4 MB/s | 306 kB     00:00    ", "(2/12): python2-dnf-3.2.0-2.fc29.noarch.rpm     1.9 MB/s | 423 kB     00:00    ", "[MIRROR] pyliblzma-0.5.3-24.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: c65bd8891ab4e7a9a614e1c19c212801bca514da70fc75324f44d9bbdb059a12(sha256)  Expected: b77e155b9a06ce6a55aed2f2ae3552025a06d465287e6580c7689dae3a612573(sha256) ", "(3/12): python2-hawkey-0.17.0-2.fc29.x86_64.rpm 1.1 MB/s |  70 kB     00:00    ", "[MIRROR] python2-gpg-1.11.1-3.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: ea308bac8f4ae330e394d14b8a6b238e7c3c1d435ff505a63b6d4ddbb73251c2(sha256)  Expected: ddf83d33a047211c02324374ae43064fbc96fc156ce5284bf45579cd43c3588c(sha256) ", "[MIRROR] python2-iniparse-0.4-32.fc29.noarch.rpm: Downloading successful, but checksum doesn't match. Calculated: 9a74056bee66742aa6600cd78acd9ab419e1278d5aa14a69272d34b5b94870fc(sha256)  Expected: 4573120918010b05f7b2bf8c49b5ade1852e7208e3f2075bf511b554f3410cbf(sha256) ", "[MIRROR] python2-gpg-1.11.1-3.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: ea308bac8f4ae330e394d14b8a6b238e7c3c1d435ff505a63b6d4ddbb73251c2(sha256)  Expected: ddf83d33a047211c02324374ae43064fbc96fc156ce5284bf45579cd43c3588c(sha256) ", "[MIRROR] python2-iniparse-0.4-32.fc29.noarch.rpm: Downloading successful, but checksum doesn't match. Calculated: 9a74056bee66742aa6600cd78acd9ab419e1278d5aa14a69272d34b5b94870fc(sha256)  Expected: 4573120918010b05f7b2bf8c49b5ade1852e7208e3f2075bf511b554f3410cbf(sha256) ", "(4/12): pyliblzma-0.5.3-24.fc29.x86_64.rpm       68 kB/s |  54 kB     00:00    ", "[MIRROR] python2-libcomps-0.1.8-14.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: 8bf1e963bd80452eb7d7a9c607fa0902ca7521ae7b79350c23301cb868775722(sha256)  Expected: 2bb7ea444a3b75059a83e72e228e07d4d0ac898a24c52a43df24cd16159af6b8(sha256) ", "[MIRROR] python2-libcomps-0.1.8-14.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: 8bf1e963bd80452eb7d7a9c607fa0902ca7521ae7b79350c23301cb868775722(sha256)  Expected: 2bb7ea444a3b75059a83e72e228e07d4d0ac898a24c52a43df24cd16159af6b8(sha256) ", "(5/12): python2-iniparse-0.4-32.fc29.noarch.rpm  59 kB/s |  42 kB     00:00    ", "(6/12): python2-gpg-1.11.1-3.fc29.x86_64.rpm    293 kB/s | 233 kB     00:00    ", "(7/12): python2-libcomps-0.1.8-14.fc29.x86_64.r 189 kB/s |  46 kB     00:00    ", "(8/12): python2-librepo-1.9.1-1.fc29.x86_64.rpm 963 kB/s |  46 kB     00:00    ", "(9/12): python2-libdnf-0.17.0-2.fc29.x86_64.rpm 6.5 MB/s | 423 kB     00:00    ", "(10/12): python2-rpm-4.14.2-1.fc30.x86_64.rpm   1.2 MB/s |  72 kB     00:00    ", "[MIRROR] python2-six-1.11.0-6.fc29.noarch.rpm: Downloading successful, but checksum doesn't match. Calculated: cdd32b90c7457600c569cde67e607a9a4f1eeb7ba4405aae8fe9fc4da168245e(sha256)  Expected: 86955d3ab54b9e366c328e56b561aea63ddbf924b4f11aaea227d6bbcd8017f1(sha256) ", "[MIRROR] python2-smartcols-0.3.0-4.fc29.x86_64.rpm: Downloading successful, but checksum doesn't match. Calculated: 5b4ae9ec46fc834db524566edf982651bc1a1e33bd7b54f09302620568d4d6c5(sha256)  Expected: 70429ae1ab5b309699ecc2acb1be32a1cc5579fb9cd43b8ebb5e6af9ef18b6ae(sha256) ", "(11/12): python2-six-1.11.0-6.fc29.noarch.rpm   147 kB/s |  34 kB     00:00    ", "(12/12): python2-smartcols-0.3.0-4.fc29.x86_64. 453 kB/s | 107 kB     00:00    ", "--------------------------------------------------------------------------------", "Total                                           1.3 MB/s | 1.8 MB     00:01     ", "Running transaction check", "Transaction check succeeded.", "Running transaction test", "Transaction test succeeded.", "Running transaction", "  Preparing        :                                                        1/1 ", "  Installing       : python2-libdnf-0.17.0-2.fc29.x86_64                   1/12 ", "  Installing       : python2-hawkey-0.17.0-2.fc29.x86_64                   2/12 ", "  Installing       : python2-smartcols-0.3.0-4.fc29.x86_64                 3/12 ", "  Installing       : python2-six-1.11.0-6.fc29.noarch                      4/12 ", "  Installing       : python2-iniparse-0.4-32.fc29.noarch                   5/12 ", "  Installing       : python2-rpm-4.14.2-1.fc30.x86_64                      6/12 ", "  Installing       : python2-librepo-1.9.1-1.fc29.x86_64                   7/12 ", "  Installing       : python2-libcomps-0.1.8-14.fc29.x86_64                 8/12 ", "  Installing       : python2-gpg-1.11.1-3.fc29.x86_64                      9/12 ", "  Installing       : python2-gobject-base-3.29.2-1.fc29.x86_64            10/12 ", "  Installing       : pyliblzma-0.5.3-24.fc29.x86_64                       11/12 ", "  Installing       : python2-dnf-3.2.0-2.fc29.noarch                      12/12 ", "  Running scriptlet: python2-dnf-3.2.0-2.fc29.noarch                      12/12 ", "  Verifying        : pyliblzma-0.5.3-24.fc29.x86_64                        1/12 ", "  Verifying        : python2-dnf-3.2.0-2.fc29.noarch                       2/12 ", "  Verifying        : python2-gobject-base-3.29.2-1.fc29.x86_64             3/12 ", "  Verifying        : python2-gpg-1.11.1-3.fc29.x86_64                      4/12 ", "  Verifying        : python2-hawkey-0.17.0-2.fc29.x86_64                   5/12 ", "  Verifying        : python2-iniparse-0.4-32.fc29.noarch                   6/12 ", "  Verifying        : python2-libcomps-0.1.8-14.fc29.x86_64                 7/12 ", "  Verifying        : python2-libdnf-0.17.0-2.fc29.x86_64                   8/12 ", "  Verifying        : python2-librepo-1.9.1-1.fc29.x86_64                   9/12 ", "  Verifying        : python2-rpm-4.14.2-1.fc30.x86_64                     10/12 ", "  Verifying        : python2-six-1.11.0-6.fc29.noarch                     11/12 ", "  Verifying        : python2-smartcols-0.3.0-4.fc29.x86_64                12/12 ", "", "Installed:", "  python2-dnf-3.2.0-2.fc29.noarch                                               ", "  pyliblzma-0.5.3-24.fc29.x86_64                                                ", "  python2-gobject-base-3.29.2-1.fc29.x86_64                                     ", "  python2-gpg-1.11.1-3.fc29.x86_64                                              ", "  python2-hawkey-0.17.0-2.fc29.x86_64                                           ", "  python2-iniparse-0.4-32.fc29.noarch                                           ", "  python2-libcomps-0.1.8-14.fc29.x86_64                                         ", "  python2-libdnf-0.17.0-2.fc29.x86_64                                           ", "  python2-librepo-1.9.1-1.fc29.x86_64                                           ", "  python2-rpm-4.14.2-1.fc30.x86_64                                              ", "  python2-six-1.11.0-6.fc29.noarch                                              ", "  python2-smartcols-0.3.0-4.fc29.x86_64                                         ", "", "Complete!"]}

    TASK [Ensure python3-dnf is present on SUT when necessary] *********************
    skipping: [/workDir/workspace/fedora-rawhide-build-pipeline/images/test_subject.qcow2] => {"changed": false, "skip_reason": "Conditional result was False"}

    TASK [Get list of rpms] ********************************************************
    ok: [/workDir/workspace/fedora-rawhide-build-pipeline/images/test_subject.qcow2] => {"changed": false, "examined": 3, "files": [{"atime": 1535972372.094, "ctime": 1535972427.991, "dev": 2049, "gid": 0, "gr_name": "root", "inode": 132366, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1535972279.0, "nlink": 1, "path": "/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.noarch.rpm", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 48544, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, {"atime": 1535972340.689, "ctime": 1535972427.991, "dev": 2049, "gid": 0, "gr_name": "root", "inode": 132367, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1535972279.0, "nlink": 1, "path": "/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.src.rpm", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 48228, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}], "matched": 2, "msg": ""}

    TASK [Check which rpms are installed] ******************************************
    ok: [/workDir/workspace/fedora-rawhide-build-pipeline/images/test_subject.qcow2] => (item={u'uid': 0, u'woth': False, u'mtime': 1535972279.0, u'inode': 132366, u'isgid': False, u'size': 48544, u'roth': True, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.noarch.rpm', u'xusr': False, u'atime': 1535972372.094, u'isdir': False, u'ctime': 1535972427.991, u'isblk': False, u'xgrp': False, u'dev': 2049, u'wgrp': False, u'isfifo': False, u'mode': u'0644', u'islnk': False}) => {"changed": false, "item": {"atime": 1535972372.094, "ctime": 1535972427.991, "dev": 2049, "gid": 0, "gr_name": "root", "inode": 132366, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1535972279.0, "nlink": 1, "path": "/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.noarch.rpm", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 48544, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, "msg": "Nothing to do"}
    failed: [/workDir/workspace/fedora-rawhide-build-pipeline/images/test_subject.qcow2] (item={u'uid': 0, u'woth': False, u'mtime': 1535972279.0, u'inode': 132367, u'isgid': False, u'size': 48228, u'roth': True, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.src.rpm', u'xusr': False, u'atime': 1535972340.689, u'isdir': False, u'ctime': 1535972427.991, u'isblk': False, u'xgrp': False, u'dev': 2049, u'wgrp': False, u'isfifo': False, u'mode': u'0644', u'islnk': False}) => {"changed": false, "item": {"atime": 1535972340.689, "ctime": 1535972427.991, "dev": 2049, "gid": 0, "gr_name": "root", "inode": 132367, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1535972279.0, "nlink": 1, "path": "/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.src.rpm", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 48228, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, "module_stderr": "Shared connection to 127.0.0.3 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_SNBaK3/ansible_module_dnf.py\", line 534, in <module>\r\n    main()\r\n  File \"/tmp/ansible_SNBaK3/ansible_module_dnf.py\", line 530, in main\r\n    ensure(module, base, params['state'], params['name'], params['autoremove'])\r\n  File \"/tmp/ansible_SNBaK3/ansible_module_dnf.py\", line 451, in ensure\r\n    if not base.resolve(allow_erasing=allow_erasing):\r\n  File \"/usr/lib/python2.7/site-packages/dnf/base.py\", line 823, in resolve\r\n    raise exc\r\ndnf.exceptions.Error: Will not install a source rpm package (standard-test-roles-2.16-1.fc30.src).\r\n", "msg": "MODULE FAILURE", "rc": 1}
    ...ignoring

    TASK [See if at least one rpm is installed] ************************************
    ok: [/workDir/workspace/fedora-rawhide-build-pipeline/images/test_subject.qcow2] => (item={'_ansible_parsed': True, 'changed': False, '_ansible_no_log': False, 'item': {u'uid': 0, u'woth': False, u'mtime': 1535972279.0, u'inode': 132366, u'isgid': False, u'size': 48544, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'islnk': False, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.noarch.rpm', u'xusr': False, u'atime': 1535972372.094, u'isdir': False, u'ctime': 1535972427.991, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2049, u'roth': True, u'isfifo': False, u'mode': u'0644', u'rusr': True}, '_ansible_item_result': True, 'failed': False, u'invocation': {u'module_args': {u'autoremove': None, u'name': [u'/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.noarch.rpm'], u'list': None, u'disable_gpg_check': False, u'conf_file': None, u'state': u'present', u'disablerepo': [], u'enablerepo': [], u'installroot': u'/'}}, u'msg': u'Nothing to do', '_ansible_ignore_errors': True, '_ansible_item_label': {u'uid': 0, u'woth': False, u'mtime': 1535972279.0, u'inode': 132366, u'isgid': False, u'size': 48544, u'wgrp': False, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'islnk': False, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.noarch.rpm', u'xusr': False, u'atime': 1535972372.094, u'isdir': False, u'ctime': 1535972427.991, u'isblk': False, u'xgrp': False, u'dev': 2049, u'roth': True, u'isfifo': False, u'mode': u'0644', u'rusr': True}}) => {"ansible_facts": {"myresult": "pass"}, "changed": false, "item": {"changed": false, "failed": false, "invocation": {"module_args": {"autoremove": null, "conf_file": null, "disable_gpg_check": false, "disablerepo": [], "enablerepo": [], "installroot": "/", "list": null, "name": ["/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.noarch.rpm"], "state": "present"}}, "item": {"atime": 1535972372.094, "ctime": 1535972427.991, "dev": 2049, "gid": 0, "gr_name": "root", "inode": 132366, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1535972279.0, "nlink": 1, "path": "/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.noarch.rpm", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 48544, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, "msg": "Nothing to do"}}
    skipping: [/workDir/workspace/fedora-rawhide-build-pipeline/images/test_subject.qcow2] => (item={'_ansible_parsed': False, '_ansible_item_result': True, '_ansible_no_log': False, 'failed': True, 'module_stderr': u'Shared connection to 127.0.0.3 closed.\r\n', 'changed': False, 'module_stdout': u'Traceback (most recent call last):\r\n  File "/tmp/ansible_SNBaK3/ansible_module_dnf.py", line 534, in <module>\r\n    main()\r\n  File "/tmp/ansible_SNBaK3/ansible_module_dnf.py", line 530, in main\r\n    ensure(module, base, params[\'state\'], params[\'name\'], params[\'autoremove\'])\r\n  File "/tmp/ansible_SNBaK3/ansible_module_dnf.py", line 451, in ensure\r\n    if not base.resolve(allow_erasing=allow_erasing):\r\n  File "/usr/lib/python2.7/site-packages/dnf/base.py", line 823, in resolve\r\n    raise exc\r\ndnf.exceptions.Error: Will not install a source rpm package (standard-test-roles-2.16-1.fc30.src).\r\n', 'item': {u'uid': 0, u'woth': False, u'mtime': 1535972279.0, u'inode': 132367, u'isgid': False, u'size': 48228, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'islnk': False, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.src.rpm', u'xusr': False, u'atime': 1535972340.689, u'isdir': False, u'ctime': 1535972427.991, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2049, u'roth': True, u'isfifo': False, u'mode': u'0644', u'rusr': True}, 'rc': 1, 'msg': u'MODULE FAILURE', '_ansible_item_label': {u'uid': 0, u'woth': False, u'mtime': 1535972279.0, u'inode': 132367, u'isgid': False, u'size': 48228, u'wgrp': False, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'islnk': False, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.src.rpm', u'xusr': False, u'atime': 1535972340.689, u'isdir': False, u'ctime': 1535972427.991, u'isblk': False, u'xgrp': False, u'dev': 2049, u'roth': True, u'isfifo': False, u'mode': u'0644', u'rusr': True}})  => {"changed": false, "item": {"changed": false, "failed": true, "item": {"atime": 1535972340.689, "ctime": 1535972427.991, "dev": 2049, "gid": 0, "gr_name": "root", "inode": 132367, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1535972279.0, "nlink": 1, "path": "/etc/yum.repos.d/standard-test-roles/standard-test-roles-2.16-1.fc30.src.rpm", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 48228, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, "module_stderr": "Shared connection to 127.0.0.3 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_SNBaK3/ansible_module_dnf.py\", line 534, in <module>\r\n    main()\r\n  File \"/tmp/ansible_SNBaK3/ansible_module_dnf.py\", line 530, in main\r\n    ensure(module, base, params['state'], params['name'], params['autoremove'])\r\n  File \"/tmp/ansible_SNBaK3/ansible_module_dnf.py\", line 451, in ensure\r\n    if not base.resolve(allow_erasing=allow_erasing):\r\n  File \"/usr/lib/python2.7/site-packages/dnf/base.py\", line 823, in resolve\r\n    raise exc\r\ndnf.exceptions.Error: Will not install a source rpm package (standard-test-roles-2.16-1.fc30.src).\r\n", "msg": "MODULE FAILURE", "rc": 1}, "skip_reason": "Conditional result was False"}

    TASK [Fail if none were installed] *********************************************
    skipping: [/workDir/workspace/fedora-rawhide-build-pipeline/images/test_subject.qcow2] => {"changed": false, "skip_reason": "Conditional result was False"}

    PLAY RECAP *********************************************************************
    /workDir/workspace/fedora-rawhide-build-pipeline/images/test_subject.qcow2 : ok=5    changed=1    unreachable=0    failed=0   
