### PR TITLE
exit with error if tests/inventory is not executable

### DIFF
--- a/config/Dockerfiles/singlehost-test/package-test.sh
+++ b/config/Dockerfiles/singlehost-test/package-test.sh
@@ -97,6 +97,10 @@ trap clean_up EXIT SIGHUP SIGINT SIGTERM
 
 # The inventory must be from the test if present (file or directory) or defaults
 if [ -e inventory ] ; then
+    if [ ! -x inventory ] ; then
+        echo "FAIL: tests/inventory file must be executable"
+        exit 1
+    fi
     ANSIBLE_INVENTORY=$(pwd)/inventory
     export ANSIBLE_INVENTORY
 fi


### PR DESCRIPTION
STI only uses the inventory file as script so it has to be executable, so make sure pipeline does not execute the playbook using inventory with wrong permission.