### PR TITLE
Fix str-container-test container

### DIFF
--- a/config/Dockerfiles/str-container-test/Dockerfile
+++ b/config/Dockerfiles/str-container-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:28
+FROM fedora:27
 LABEL maintainer "https://github.com/CentOS-PaaS-SIG/ci-pipeline"
 LABEL description="This container is meant to \
 run standard-test-roles defined tests targeting \
@@ -24,23 +24,13 @@ RUN dnf -y install ansible \
         rsync \
         standard-test-roles \
         sudo \
+        systemd \
         wget \
         && dnf clean all
 
 # WORKAROUND: use str from pip
 # Official STR does is not ansible 2.4 compatible, ansible 2.5 has no repo
 RUN pip install ansible==2.5.8
-
-# Systemd hacking
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-rm -f /lib/systemd/system/multi-user.target.wants/*;\
-rm -f /etc/systemd/system/*.wants/*;\
-rm -f /lib/systemd/system/local-fs.target.wants/*; \
-rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-rm -f /lib/systemd/system/basic.target.wants/*;\
-rm -f /lib/systemd/system/anaconda.target.wants/*; \
-systemctl enable docker
 
 # Set default ansible inventory for STR
 ENV ANSIBLE_INVENTORY=/usr/share/ansible/inventory


### PR DESCRIPTION
With Fedora 28, the pod is created and it fails instantly with "The agent has not been fully initialized yet." For some reason, I don't see this with Fedora 27. Also, with the Fedora 27 container, I have confirmed I don't need all the systemd hacking, /usr/sbin/init with the no VOLUME line seems to be sufficient.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>