### PR TITLE
Updates for jms-messaging-1.1.1

### DIFF
--- a/JenkinsfileTrigger
+++ b/JenkinsfileTrigger
@@ -1,3 +1,5 @@
+import groovy.json.JsonOutput
+
 properties(
         [
                 buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '50', daysToKeepStr: '', numToKeepStr: '100')),
@@ -153,22 +155,25 @@ node('master') {
                         def jobproperties_map = readProperties file: "${env.WORKSPACE}/job.properties"
                         job_properties = jobproperties_map.collect { key, value -> return key+'='+value }
                         withEnv(job_properties) {
-                            // Populate message Properties
-                            messageProperties = "topic=${env.topic}\n" +
-                                    "build_url=${BUILD_URL}\n" +
-                                    "build_id=${BUILD_ID}\n" +
-                                    "branch=${env.branch}\n" +
-                                    "ref=fedora/${env.branch}/x86_64/atomic-host\n" +
-                                    "rev=${env.fed_rev}\n" +
-                                    "repo=${env.fed_repo}\n" +
-                                    "namespace=${env.fed_namespace}\n" +
-                                    "username=fedora-atomic\n" +
-                                    "test_guidance=''\n" +
-                                    "status=${currentBuild.currentResult}"
-                            messageContent = ''
+                            messageProperties = ''
+                            // Populate message content
+                            messageContent = [
+                                    topic: env.topic,
+                                    build_url: BUILD_URL,
+                                    build_id: BUILD_ID,
+                                    branch: env.branch,
+                                    ref: 'fedora/' + env.branch + '/x86_64/atomic-host',
+                                    rev: env.fed_rev,
+                                    repo: env.fed_repo,
+                                    namespace: env.fed_namespace,
+                                    username: 'fedora-atomic',
+                                    test_guidance: '',
+                                    status: currentBuild.currentResult
+                            ]
+                            messageContentString = JsonOutput.toJson(messageContent)
 
                             // Send message org.centos.prod.ci.pipeline.package.queued or .ignore on fedmsg
-                            sendMessage(messageProperties, messageContent)
+                            sendMessage(messageProperties, messageContentString)
                         }
                     }
                 }

--- a/JenkinsfileTrigger
+++ b/JenkinsfileTrigger
@@ -17,7 +17,17 @@ properties(
                     ]
                 ),
                 pipelineTriggers(
-                        [[$class: 'CIBuildTrigger', checks: [], providerName: 'fedora-fedmsg', selector: 'topic = "org.fedoraproject.prod.git.receive"']]
+                        [[$class: 'CIBuildTrigger',
+                          noSquash: true,
+                          providerData: [
+                              $class: 'FedMsgSubscriberProviderData',
+                              name: 'fedora-fedmsg',
+                              overrides: [
+                                  topic: 'org.fedoraproject.prod.git.receive'
+                              ],
+                              checks: []
+                          ]
+                        ]]
                 )
         ]
 )

--- a/config/s2i/jenkins/master/configuration/jobs/ci-pipeline-trigger/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/ci-pipeline-trigger/config.xml
@@ -69,11 +69,16 @@
       </hudson.model.ParametersDefinitionProperty>
       <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
          <triggers>
-            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.0.35">
+            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.1">
                <spec />
-               <selector>topic = "org.fedoraproject.prod.git.receive"</selector>
-               <providerName>fedora-fedmsg</providerName>
-               <checks />
+               <noSquash>true</noSquash>
+               <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">
+                  <name>fedora-fedmsg</name>
+                  <overrides>
+                     <topic>org.fedoraproject.prod.git.receive</topic>
+                  </overrides>
+                  <checks />
+               </providerData>
             </com.redhat.jenkins.plugins.ci.CIBuildTrigger>
          </triggers>
       </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>

--- a/config/s2i/jenkins/master/configuration/jobs/ci-pipeline-trigger/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/ci-pipeline-trigger/config.xml
@@ -69,7 +69,7 @@
       </hudson.model.ParametersDefinitionProperty>
       <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
          <triggers>
-            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.1">
+            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.2">
                <spec />
                <noSquash>true</noSquash>
                <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">

--- a/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-receiver-test/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-receiver-test/config.xml
@@ -16,7 +16,7 @@
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
     <triggers>
-       <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.1">
+       <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.2">
           <spec />
           <noSquash>true</noSquash>
           <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">

--- a/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-receiver-test/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-receiver-test/config.xml
@@ -16,12 +16,20 @@
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
     <triggers>
-        <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.0.20">
-            <spec></spec>
-            <selector>scott = &quot;true&quot;</selector>
-            <providerName>fedora-fedmsg-devel</providerName>
-            <checks/>
-        </com.redhat.jenkins.plugins.ci.CIBuildTrigger>
+       <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.1">
+          <spec />
+          <noSquash>true</noSquash>
+          <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">
+             <name>fedora-fedmsg-devel</name>
+             <overrides />
+             <checks>
+                <com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck>
+                   <field>scott</field>
+                   <expectedValue>true</expectedValue>
+                </com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck>
+             </checks>
+          </providerData>
+       </com.redhat.jenkins.plugins.ci.CIBuildTrigger>
     </triggers>
     <concurrentBuild>false</concurrentBuild>
     <builders>

--- a/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-sender-test/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-sender-test/config.xml
@@ -17,7 +17,7 @@
     <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <builders>
-        <com.redhat.jenkins.plugins.ci.CIMessageBuilder plugin="jms-messaging@1.1.1">
+        <com.redhat.jenkins.plugins.ci.CIMessageBuilder plugin="jms-messaging@1.1.2">
           <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgPublisherProviderData">
             <name>fedora-fedmsg-devel</name>
             <!--<messageProperties>scott=true</messageProperties>-->

--- a/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-sender-test/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedmsg-devel-sender-test/config.xml
@@ -17,12 +17,13 @@
     <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <builders>
-        <com.redhat.jenkins.plugins.ci.CIMessageBuilder plugin="jms-messaging@1.0.20">
-            <providerName>fedora-fedmsg-devel</providerName>
-            <messageType>Custom</messageType>
-            <messageProperties>scott=true</messageProperties>
-            <messageContent></messageContent>
+        <com.redhat.jenkins.plugins.ci.CIMessageBuilder plugin="jms-messaging@1.1.1">
+          <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgPublisherProviderData">
+            <name>fedora-fedmsg-devel</name>
+            <!--<messageProperties>scott=true</messageProperties>-->
+            <messageContent/>
             <failOnError>false</failOnError>
+          </providerData>
         </com.redhat.jenkins.plugins.ci.CIMessageBuilder>
     </builders>
     <publishers/>

--- a/config/s2i/jenkins/master/configuration/jobs/fedora-build-pipeline-trigger/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedora-build-pipeline-trigger/config.xml
@@ -42,7 +42,7 @@
       </hudson.model.ParametersDefinitionProperty>
       <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
          <triggers>
-            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.1">
+            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.2">
                <spec />
                <noSquash>true</noSquash>
                <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">

--- a/config/s2i/jenkins/master/configuration/jobs/fedora-pr-added-pipeline-trigger/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedora-pr-added-pipeline-trigger/config.xml
@@ -34,7 +34,7 @@
       <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty />
       <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
          <triggers>
-            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.1">
+            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.2">
                <spec />
                <noSquash>true</noSquash>
                <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">

--- a/config/s2i/jenkins/master/configuration/jobs/fedora-pr-added-pipeline-trigger/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedora-pr-added-pipeline-trigger/config.xml
@@ -34,16 +34,21 @@
       <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty />
       <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
          <triggers>
-            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.0.35">
+            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.1">
                <spec />
-               <selector>topic = "org.fedoraproject.prod.pagure.pull-request.new" OR topic = "org.fedoraproject.prod.pagure.pull-request.comment.added"</selector>
-               <providerName>fedora-fedmsg</providerName>
-               <checks>
-                  <com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck>
-                     <field>$.pullrequest.project.namespace</field>
-                     <expectedValue>rpms</expectedValue>
-                  </com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck>
-               </checks>
+               <noSquash>true</noSquash>
+               <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">
+                  <name>fedora-fedmsg</name>
+                  <overrides>
+                     <topic>org.fedoraproject.prod.pagure.pull-request.comment.added</topic>
+                  </overrides>
+                  <checks>
+                     <com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck>
+                        <field>$.pullrequest.project.namespace</field>
+                        <expectedValue>rpms</expectedValue>
+                     </com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck>
+                  </checks>
+               </providerData>
             </com.redhat.jenkins.plugins.ci.CIBuildTrigger>
          </triggers>
       </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>

--- a/config/s2i/jenkins/master/configuration/jobs/fedora-pr-new-pipeline-trigger/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedora-pr-new-pipeline-trigger/config.xml
@@ -34,7 +34,7 @@
       <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty />
       <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
          <triggers>
-            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.1">
+            <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.2">
                <spec />
                <noSquash>true</noSquash>
                <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">

--- a/config/s2i/jenkins/master/configuration/jobs/fedora-pr-new-pipeline-trigger/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedora-pr-new-pipeline-trigger/config.xml
@@ -3,6 +3,7 @@
    <actions>
       <org.jenkinsci.plugins.workflow.multibranch.JobPropertyTrackerAction plugin="workflow-multibranch@2.17">
          <jobPropertyDescriptors>
+            <string>org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty</string>
             <string>hudson.model.ParametersDefinitionProperty</string>
             <string>org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty</string>
             <string>jenkins.model.BuildDiscarderProperty</string>
@@ -25,21 +26,12 @@
       <jenkins.model.BuildDiscarderProperty>
          <strategy class="hudson.tasks.LogRotator">
             <daysToKeep>-1</daysToKeep>
-            <numToKeep>500</numToKeep>
+            <numToKeep>100</numToKeep>
             <artifactDaysToKeep>-1</artifactDaysToKeep>
-            <artifactNumToKeep>500</artifactNumToKeep>
+            <artifactNumToKeep>100</artifactNumToKeep>
          </strategy>
       </jenkins.model.BuildDiscarderProperty>
-      <hudson.model.ParametersDefinitionProperty>
-         <parameterDefinitions>
-            <hudson.model.StringParameterDefinition>
-               <name>CI_MESSAGE</name>
-               <description>fedora-fedmsg</description>
-               <defaultValue>{}</defaultValue>
-               <trim>false</trim>
-            </hudson.model.StringParameterDefinition>
-         </parameterDefinitions>
-      </hudson.model.ParametersDefinitionProperty>
+      <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty />
       <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
          <triggers>
             <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.1">
@@ -48,25 +40,35 @@
                <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">
                   <name>fedora-fedmsg</name>
                   <overrides>
-                     <topic>org.fedoraproject.prod.buildsys.build.state.change</topic>
+                     <topic>org.fedoraproject.prod.pagure.pull-request.new</topic>
                   </overrides>
                   <checks>
                      <com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck>
-                        <field>new</field>
-                        <expectedValue>1</expectedValue>
+                        <field>$.pullrequest.project.namespace</field>
+                        <expectedValue>rpms</expectedValue>
                      </com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck>
                   </checks>
                </providerData>
             </com.redhat.jenkins.plugins.ci.CIBuildTrigger>
          </triggers>
       </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+      <hudson.model.ParametersDefinitionProperty>
+         <parameterDefinitions>
+            <hudson.model.StringParameterDefinition>
+               <name>CI_MESSAGE</name>
+               <description>CI_MESSAGE</description>
+               <defaultValue>{"commit":{"username":"zdohnal","stats":{"files":{"README.patches":{"deletions":0,"additions":30,"lines":30},"sources":{"deletions":1,"additions":1,"lines":2},"vim.spec":{"deletions":7,"additions":19,"lines":26},".gitignore":{"deletions":0,"additions":1,"lines":1},"vim-8.0-rhbz1365258.patch":{"deletions":0,"additions":12,"lines":12}},"total":{"deletions":8,"files":5,"additions":63,"lines":71}},"name":"Zdenek Dohnal","rev":"3ff427e02625f810a2cedb754342be44d6161b39","namespace":"rpms","agent":"zdohnal","summary":"Merge branch f25 into f26","repo":"vim","branch":"f26","seen":false,"path":"/srv/git/repositories/rpms/vim.git","message":"Merge branch 'f25' into f26 ","email":"zdohnal@redhat.com"},"topic":"org.fedoraproject.prod.git.receive"}</defaultValue>
+               <trim>false</trim>
+            </hudson.model.StringParameterDefinition>
+         </parameterDefinitions>
+      </hudson.model.ParametersDefinitionProperty>
    </properties>
    <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.45">
       <scm class="hudson.plugins.git.GitSCM" plugin="git@3.8.0">
          <configVersion>2</configVersion>
          <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
-               <url>https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline</url>
+               <url>https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git</url>
             </hudson.plugins.git.UserRemoteConfig>
          </userRemoteConfigs>
          <branches>
@@ -78,8 +80,8 @@
          <submoduleCfg class="list" />
          <extensions />
       </scm>
-      <scriptPath>JenkinsfileBuildTrigger</scriptPath>
-      <lightweight>true</lightweight>
+      <scriptPath>JenkinsfilePRTrigger</scriptPath>
+      <lightweight>false</lightweight>
    </definition>
    <triggers />
    <disabled>false</disabled>

--- a/config/s2i/jenkins/master/plugins.txt
+++ b/config/s2i/jenkins/master/plugins.txt
@@ -58,7 +58,7 @@ jackson2-api:2.8.11.1
 javadoc:1.4
 jenkins-design-language:1.5.0
 jira:2.5.2
-jms-messaging:1.0.36
+jms-messaging:1.1.1
 job-dsl:1.69
 jquery-detached:1.2.1
 jsch:0.1.54.2

--- a/config/s2i/jenkins/master/plugins.txt
+++ b/config/s2i/jenkins/master/plugins.txt
@@ -58,7 +58,7 @@ jackson2-api:2.8.11.1
 javadoc:1.4
 jenkins-design-language:1.5.0
 jira:2.5.2
-jms-messaging:1.1.1
+jms-messaging:1.1.2
 job-dsl:1.69
 jquery-detached:1.2.1
 jsch:0.1.54.2

--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -5,6 +5,7 @@ import org.centos.*
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateAction
+import groovy.json.JsonOutput
 
 /**
  * Library to setup and configure the host the way ci-pipeline requires
@@ -228,12 +229,12 @@ def getRsyncBranch() {
 def setMessageFields(String messageType) {
     topic = "${MAIN_TOPIC}.ci.pipeline.${messageType}"
 
-    // Create a HashMap of default message property keys and values
+    // Create a HashMap of default message content keys and values
     // These properties should be applicable to ALL message types.
     // If something is applicable to only some subset of messages,
     // add it below per the existing examples.
 
-    def messageProperties = [
+    def messageContent = [
             branch           : env.branch,
             build_id         : env.BUILD_ID,
             build_url        : env.JENKINS_URL + 'blue/organizations/jenkins/' + env.JOB_NAME + '/detail/' + env.JOB_NAME + '/' + env.BUILD_NUMBER + '/pipeline/',
@@ -255,46 +256,37 @@ def setMessageFields(String messageType) {
                         'compose.test.integration.running', 'compose.test.integration.complete', 'image.running', 'image.complete',
                         'image.test.smoke.running', 'image.test.smoke.complete'
     ]) {
-        messageProperties.compose_url = "${env.HTTP_BASE}/${env.branch}/ostree"
+        messageContent.compose_url = "${env.HTTP_BASE}/${env.branch}/ostree"
     }
 
     // Add image type to appropriate message types
     if (messageType in ['image.running', 'image.complete', 'image.test.smoke.running', 'image.test.smoke.complete'
     ]) {
-        messageProperties.type = messageType == 'image.running' ? "''" : 'qcow2'
+        messageContent.type = messageType == 'image.running' ? "''" : 'qcow2'
     }
 
     // Add image_url to appropriate message types
     if (messageType in ['image.complete', 'image.test.smoke.running', 'image.test.smoke.complete']) {
-        messageProperties.image_url = messageType == 'image.running' ? "''" : env.image2boot
+        messageContent.image_url = messageType == 'image.running' ? "''" : env.image2boot
     }
 
     // Add image_name to appropriate message types
     if (messageType in ['image.complete', 'image.test.smoke.running', 'image.test.smoke.complete']) {
-        messageProperties.image_name = messageType == 'image.running' ? "''" : env.image_name
+        messageContent.image_name = messageType == 'image.running' ? "''" : env.image_name
     }
 
-    // Create a string to hold the data from the messageProperties hash map
-    String messagePropertiesString = ''
+    // Create a string to hold the data from the messageContent hash map
+    String messageContentString = JsonOutput.toJson(messageContent)
 
-    messageProperties.each { k,v ->
-        // Don't add a new line to the last item in the hash map when adding it to the messagePropertiesString
-        if ( k == messageProperties.keySet().last()){
-            messagePropertiesString += "${k}=${v}"
-        } else {
-            messagePropertiesString += "${k}=${v}\n"
-        }
-    }
-
-    def messageContentString = ''
+    def messagePropertiesString = ''
 
     return [ 'topic': topic, 'properties': messagePropertiesString, 'content': messageContentString ]
 }
 
 /**
  * Library to send message
- * @param msgProps - The message properties in key=value form, one key/value per line ending in '\n'
- * @param msgContent - Message content.
+ * @param msgProps - Message Properties - empty string for fedmsg
+ * @param msgContent - Message content in map form
  * @return
  */
 def sendMessage(String msgTopic, String msgProps, String msgContent) {
@@ -327,8 +319,8 @@ def sendMessage(String msgTopic, String msgProps, String msgContent) {
 
 /**
  * Library to send message
- * @param msgProps - The message properties in key=value form, one key/value per line ending in '\n'
- * @param msgContent - Message content.
+ * @param msgProps - Message Properties - empty string for fedmsg
+ * @param msgContent - Message content in map form
  * @param msgAuditFile - File containing all past messages. It will get appended to.
  * @param fedmsgRetryCount number of times to keep trying.
  * @return


### PR DESCRIPTION
We need jms-messaging-1.1.1 to send out nested arrays on fedmsg. These are the changes to resolve the syntax changes between 1.0.36 and  1.1.1

We can no longer have two topics for one trigger job, so some job(s) had to be split.