### PR TITLE
Workaround socket timeout losing --wait

### DIFF
--- a/config/s2i/jenkins/slave/Dockerfile
+++ b/config/s2i/jenkins/slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7:v3.11
+FROM openshift/jenkins-slave-base-centos7:v3.6
 ##
 ## ------------------------------------->  ^^ this is needed
 ## since the centosCI openshift cluster

--- a/config/s2i/jenkins/slave/Dockerfile
+++ b/config/s2i/jenkins/slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7:v3.6
+FROM openshift/jenkins-slave-base-centos7:v3.11
 ##
 ## ------------------------------------->  ^^ this is needed
 ## since the centosCI openshift cluster

--- a/src/org/centos/pipeline/PipelineUtils.groovy
+++ b/src/org/centos/pipeline/PipelineUtils.groovy
@@ -979,10 +979,19 @@ def buildImage(String openshiftProject, String buildConfig) {
             echo "Resulting Build: " + out
 
             def describeStr = openshift.selector(out).describe()
-            out = describeStr.out.trim()
+            outTrim = describeStr.out.trim()
+            
+            // --wait is being lost due to socket timeouts
+            buildRunning = true
+            while (buildRunning) {
+                describeStr = openshift.selector(out).describe()
+                outTrim = describeStr.out.trim()
+                buildRunning = sh(script: "echo \"${outTrim}\" | grep '^Status:' | grep -E 'New|Pending|Running'", returnStatus: true) == 0
+                sleep 60
+            }
 
             def imageHash = sh(
-                    script: "echo \"${out}\" | grep 'Image Digest:' | cut -f2- -d:",
+                    script: "echo \"${outTrim}\" | grep 'Image Digest:' | cut -f2- -d:",
                     returnStdout: true
             ).trim()
             echo "imageHash: ${imageHash}"
@@ -1016,10 +1025,19 @@ def buildStableImage(String openshiftProject, String buildConfig) {
             echo "Resulting Build: " + out
 
             def describeStr = openshift.selector(out).describe()
-            out = describeStr.out.trim()
+            outTrim = describeStr.out.trim()
+
+            // --wait is being lost due to socket timeouts
+            buildRunning = true
+            while (buildRunning) {
+                describeStr = openshift.selector(out).describe()
+                outTrim = describeStr.out.trim()
+                buildRunning = sh(script: "echo \"${outTrim}\" | grep '^Status:' | grep -E 'New|Pending|Running'", returnStatus: true) == 0
+                sleep 60
+            }
 
             def imageHash = sh(
-                    script: "echo \"${out}\" | grep 'Image Digest:' | cut -f2- -d:",
+                    script: "echo \"${outTrim}\" | grep 'Image Digest:' | cut -f2- -d:",
                     returnStdout: true
             ).trim()
             echo "imageHash: ${imageHash}"


### PR DESCRIPTION
We keep getting java socket timeouts when oc start-build begins, so the --wait is lost and the build proceeds with an unfinished image, which fails. This seems to work around it.