### PR TITLE
Fast fix to improve readability for ansible logs

### DIFF
--- a/config/Dockerfiles/singlehost-test/package-test.sh
+++ b/config/Dockerfiles/singlehost-test/package-test.sh
@@ -125,7 +125,7 @@ set -u
 set -xo pipefail
 for playbook in tests*.yml; do
 	if [ -f ${playbook} ]; then
-		timeout 4h ansible-playbook -v --inventory=$ANSIBLE_INVENTORY $PYTHON_INTERPRETER \
+		ANSIBLE_STDOUT_CALLBACK=yaml timeout 4h ansible-playbook -v --inventory=$ANSIBLE_INVENTORY $PYTHON_INTERPRETER \
 			--tags ${TAG} ${playbook} $@ | tee ${TEST_ARTIFACTS}/${playbook}-run.txt
 	fi
 done


### PR DESCRIPTION
yaml callback plugin is available sinse Ansible 2.5: https://docs.ansible.com/ansible/latest/plugins/callback/yaml.html

It improves readability, especially for cmd stages of the execution.

Example output:

```
TASK [standard-test-basic : Execute tests] ************************************************************************************************************************************************************************
changed: [localhost] => (item={'smoke': {'dir': 'python/smoke', 'run': 'VERSION=3.7 ./venv.sh'}}) => changed=true 
  cmd: |-
    if [[ -z ${TEST} ]]; then
     echo "FAIL: Test case name is not set" >> /tmp/artifacts//test.log
     exit
     fi
     if [[ -z ${TEST_DIR} ]]; then
     echo "FAIL: Test directory for $TEST not found" >> /tmp/artifacts//test.log
     exit
     fi
     if [[ -z ${TEST_CMD} ]]; then
     echo "FAIL: Does not know how to run $TEST" >> /tmp/artifacts//test.log
     exit
     fi
     log_file_name=$(echo $TEST | sed -e 's/\//-/g').log
     logfile=/tmp/artifacts//str_${log_file_name}
     exec 2>>$logfile 1>>$logfile
     cd $TEST_DIR
     #if command is a file make it executable
     cmd="$(echo $TEST_CMD | awk '{print $1;}')"
     if [ -f "$cmd" ]; then
     chmod 0775 "$cmd"
     fi
     status="FAIL"
     #execute the test
     eval $TEST_CMD
     if [ $? -eq 0 ]; then
     status="PASS"
     fi
     echo "${status} $TEST" >> /tmp/artifacts//test.log
     # Add test status as prefix to test case log
     mv ${logfile} /tmp/artifacts//${status}_str_${log_file_name}
  delta: '0:00:11.184706'
  end: '2019-05-13 22:29:35.965023'
  item:
    smoke:
      dir: python/smoke
      run: VERSION=3.7 ./venv.sh
  rc: 0
  start: '2019-05-13 22:29:24.780317'
  stderr: ''
  stderr_lines: []
  stdout: ''
  stdout_lines: <omitted>
```

It is not an ideal solution, but it is very easy to apply.