### PR TITLE
force sync artifacts in the end of test execution

### DIFF
--- a/config/Dockerfiles/singlehost-test/Dockerfile
+++ b/config/Dockerfiles/singlehost-test/Dockerfile
@@ -8,7 +8,7 @@ upstreamfirst.fedorainfracloud.org. It also can run \
 integration tests from the projectatomic repo by calling \
 the integration-test.sh script."
 
-RUN dnf -y module enable standard-test-roles
+RUN dnf -y module enable standard-test-roles && dnf clean all
 
 # Install all package requirements
 # rpm-build is required by standard-test-source role
@@ -22,9 +22,9 @@ RUN dnf -y install ansible \
         git \
         libguestfs-tools-c \
         libselinux-python \
-        python-dnf \
-        python-pip \
+        python2-pip \
         python3-devel \
+        python3-dnf \
         qemu-img \
         qemu-kvm \
         rpm-build \
@@ -43,7 +43,7 @@ RUN dnf -y install ansible \
 RUN pip install ansible==2.7.7
 
 # Copy the build scripts to the container
-COPY package-test.sh integration-test.sh upstreamfirst-test.sh verify-rpm.sh rpm-verify.yml resize-qcow2.sh /tmp/
+COPY package-test.sh integration-test.sh upstreamfirst-test.sh verify-rpm.sh rpm-verify.yml resize-qcow2.sh sync-artifacts.yml /tmp/
 
 ENV ANSIBLE_INVENTORY=/usr/share/ansible/inventory/standard-inventory-qcow2
 

--- a/config/Dockerfiles/singlehost-test/package-test.sh
+++ b/config/Dockerfiles/singlehost-test/package-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -xeo pipefail
 
 CURRENTDIR=$(pwd)
 if [ ${CURRENTDIR} == "/" ] ; then
@@ -20,6 +20,8 @@ fi
 rm -rf ${TEST_ARTIFACTS}
 mkdir -p ${TEST_ARTIFACTS}
 
+{ #group for tee
+
 # It was requested that these tests be run with latest rpm of standard-test-roles
 # Try to update for few times, if for some reason could not update,
 # continue test with installed STR version
@@ -37,7 +39,7 @@ rpm -q standard-test-roles
 
 if [ -z "${package:-}" ]; then
 	if [ $# -lt 1 ]; then
-		echo "No package defined"
+        echo "No package defined" | tee "${TEST_ARTIFACTS}/FAIL_package-test.log"
 		exit 2
 	else
 		package="$1"
@@ -53,7 +55,7 @@ fi
 
 # Make sure we have or have downloaded the test subject
 if [ -z "${TEST_SUBJECTS:-}" ]; then
-	echo "No subject defined"
+    echo "No subject defined"  | tee "${TEST_ARTIFACTS}/FAIL_package-test.log"
 	exit 2
 elif ! file ${TEST_SUBJECTS:-}; then
 	wget -q -O testimage.qcow2 ${TEST_SUBJECTS}
@@ -63,8 +65,8 @@ fi
 # Check out the dist-git repository for this package
 rm -rf ${package}
 if ! git clone ${TEST_LOCATION}; then
-	echo "No dist-git repo for this package! Exiting..."
-	exit 0
+    echo "Could not clone dist-git repo for this package! Exiting..."  | tee "${TEST_ARTIFACTS}/FAIL_package-test.log"
+	exit 1
 fi
 
 # The specification requires us to invoke the tests in the checkout directory
@@ -89,16 +91,35 @@ else
      exit 0
 fi
 
+PATH_PIPELINE_INVENTORY=""
+
+function sync_artifacts {
+    if [[ -z $PATH_PIPELINE_INVENTORY ]]; then
+        return
+    fi
+    # Run a playbook to get logs from the VM
+    timeout 10m ansible-playbook --inventory=$PATH_PIPELINE_INVENTORY $PYTHON_INTERPRETER \
+         /tmp/sync-artifacts.yml || true
+}
+
 # This will introduce a problem with concurrency as it has no locks
 function clean_up {
+    ret=$?
+    sync_artifacts || true
+    killall /usr/bin/qemu-system-x86_64 > /dev/null 2>&1 || true
     rm -rf tests/package
     mkdir -p tests/package
     cp -rp ${TEST_ARTIFACTS}/* tests/package/
-    cat ${TEST_ARTIFACTS}/test.log
+    if [[ -e ${TEST_ARTIFACTS}/test.log ]]; then
+        cat ${TEST_ARTIFACTS}/test.log
+    fi
     set +u
     if [[ ! -z "${RSYNC_USER}" && ! -z "${RSYNC_SERVER}" && ! -z "${RSYNC_DIR}" && ! -z "${RSYNC_PASSWORD}"  && ! -z "${RSYNC_BRANCH}" ]]; then
         RSYNC_LOCATION="${RSYNC_USER}@${RSYNC_SERVER}::${RSYNC_DIR}/${RSYNC_BRANCH}"
         rsync --stats -arv tests ${RSYNC_LOCATION}/repo/${package}_repo/logs
+    fi
+    if [[ $ret -eq 124 ]]; then
+        echo "FAIL: test aborted due to timeout" | tee "${TEST_ARTIFACTS}/FAIL_package-test.log"
     fi
 }
 trap clean_up EXIT SIGHUP SIGINT SIGTERM
@@ -106,7 +127,7 @@ trap clean_up EXIT SIGHUP SIGINT SIGTERM
 # The inventory must be from the test if present (file or directory) or defaults
 if [ -e inventory ] ; then
     if [ ! -x inventory ] ; then
-        echo "FAIL: tests/inventory file must be executable"
+        echo "FAIL: tests/inventory file must be executable" | tee "${TEST_ARTIFACTS}/FAIL_package-test.log"
         exit 1
     fi
     ANSIBLE_INVENTORY=$(pwd)/inventory
@@ -121,13 +142,59 @@ if [[ ! -z "${python3}" && "${python3}" == "yes" ]] ; then
 fi
 set -u
 
+function provision_with_retry {
+    # the script is running with set -e, but in this case we don't want to abort
+    # if command fails, so set +e
+    set +e
+    attempts=5
+
+    until [[ $attempts -eq 0 ]]; do
+        # WORKAROUND until we have a better way to detect the VM failed to boot up
+        # kill any other VM that might be running
+        killall /usr/bin/qemu-system-x86_64 > /dev/null 2>&1 || true
+        rm -f pipeline_inventory.yaml
+        # set TEST_DEBUG so the VM stays up
+        TEST_DEBUG=1 TEST_SUBJECTS=$TEST_SUBJECTS ansible-inventory --inventory=$ANSIBLE_INVENTORY --list --yaml | tee pipeline_inventory.yaml
+        python3 -c 'import yaml; _dict = yaml.load(open("pipeline_inventory.yaml")); print(_dict["all"]["children"]["localhost"])'
+        ret=$?
+        # success
+        if [[ $ret -eq 0 ]]; then
+            break
+        fi
+        let attempts-=1
+    done
+    if [[ $ret -ne 0 ]]; then
+        echo "FAIL: Could not provision inventory..."
+        # add some sleep to help debug
+        cat pipeline_inventory.yaml
+        echo "FAIL: invalid inventory" | tee "${TEST_ARTIFACTS}/FAIL_package-test.log"
+        exit 1
+    fi
+
+    set -e
+    PATH_PIPELINE_INVENTORY=$(pwd)/pipeline_inventory.yaml
+    return 0
+}
+
+if [[ `ls -1 tests*.yml 2>/dev/null | wc -l` == 0 ]]; then
+    echo "FAIL: there is no tests*.yml" | tee "${TEST_ARTIFACTS}/FAIL_package-test.log"
+    exit 1
+fi
+
 # Invoke each playbook according to the specification
-set -xo pipefail
 for playbook in tests*.yml; do
 	if [ -f ${playbook} ]; then
-		ANSIBLE_STDOUT_CALLBACK=yaml timeout 4h ansible-playbook -v --inventory=$ANSIBLE_INVENTORY $PYTHON_INTERPRETER \
-			--tags ${TAG} ${playbook} $@ | tee ${TEST_ARTIFACTS}/${playbook}-run.txt
+        ansible-playbook --list-tags ${playbook} > playbook-tags.txt
+        if ! grep -e "TASK TAGS: \[.*\<${TAG}\>.*\]" playbook-tags.txt; then
+            echo "SKIP: ${playbook} doesn't run on ${TAG}" >> ${TEST_ARTIFACTS}/test.log
+            continue
+        fi
+        # should provision fresh VM for each tests* playbook
+        provision_with_retry
+        ANSIBLE_STDOUT_CALLBACK=yaml timeout 4h ansible-playbook -v --inventory=pipeline_inventory.yaml $PYTHON_INTERPRETER \
+            --tags ${TAG} ${playbook} $@ | tee ${TEST_ARTIFACTS}/${playbook}-run.txt
 	fi
 done
 popd
 popd
+} 2>&1 | tee ${TEST_ARTIFACTS}/console.log #group for tee

--- a/config/Dockerfiles/singlehost-test/sync-artifacts.yml
+++ b/config/Dockerfiles/singlehost-test/sync-artifacts.yml
@@ -1,0 +1,17 @@
+---
+- hosts: localhost
+  tags:
+  - always
+  vars:
+    remote_artifacts: /tmp/artifacts/
+    artifacts: "{{ lookup('env', 'TEST_ARTIFACTS')|default('./artifacts', true) }}"
+
+  tasks:
+  - name: Pull out the logs from test environment to test runner
+    synchronize:
+      dest: "{{ artifacts }}/"
+      src: "{{ remote_artifacts }}/"
+      mode: pull
+      ssh_args: "-o UserKnownHostsFile=/dev/null"
+    when: artifacts|default("") != ""
+    ignore_errors: true


### PR DESCRIPTION
Make sure artifacts are synced after tests are executed,
even if test playbook didn't do it or got aborted