### PR TITLE
Proposed fix for Fedora CI issue 104

### DIFF
--- a/config/s2i/jenkins/jenkins-persistent-buildconfig-template.yaml
+++ b/config/s2i/jenkins/jenkins-persistent-buildconfig-template.yaml
@@ -75,7 +75,7 @@ objects:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: docker.io/openshift/jenkins-2-centos7:v3.11
+          name: docker.io/openshift/jenkins-2-centos7:v3.6
       type: Source
     triggers:
     - type: ConfigChange


### PR DESCRIPTION
https://pagure.io/fedora-ci/general/issue/104

Our cluster is openshift 3.6 and requires the 3.6 cli per pagure fedora-ci issue 104

Also, a quick glance shows other images related to jenkins are also still on 3.6, which is expected given our cluster:
https://github.com/CentOS-PaaS-SIG/ci-pipeline/blob/master/config/s2i/jenkins/slave/Dockerfile#L1